### PR TITLE
QE3 - added OFeed platform support

### DIFF
--- a/quickevent/app/quickevent/CMakeLists.txt
+++ b/quickevent/app/quickevent/CMakeLists.txt
@@ -59,6 +59,8 @@ add_executable(quickevent
 	plugins/Event/src/services/emmaclientwidget.cpp
 	plugins/Event/src/services/oresultsclient.cpp
 	plugins/Event/src/services/oresultsclientwidget.cpp
+	plugins/Event/src/services/ofeed/ofeedclient.cpp
+	plugins/Event/src/services/ofeed/ofeedclientwidget.cpp
 	plugins/Event/src/services/service.cpp
 	plugins/Event/src/services/serviceswidget.cpp
 	plugins/Event/src/services/servicewidget.cpp

--- a/quickevent/app/quickevent/plugins/Event/src/eventplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/eventplugin.cpp
@@ -33,6 +33,7 @@
 #include <qf/core/sql/transaction.h>
 #include <qf/core/utils/fileutils.h>
 #include <plugins/Event/src/services/oresultsclient.h>
+#include <plugins/Event/src/services/ofeed/ofeedclient.h>
 
 #include <QInputDialog>
 #include <QSqlDatabase>
@@ -372,6 +373,9 @@ void EventPlugin::onInstalled()
 
 	auto *oresults_client = new services::OResultsClient(this);
 	services::Service::addService(oresults_client);
+
+	auto *ofeed_client = new services::OFeedClient(this);
+	services::Service::addService(ofeed_client);
 
 	auto *emma_client = new services::EmmaClient(this);
 	services::Service::addService(emma_client);

--- a/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclient.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclient.cpp
@@ -1,0 +1,367 @@
+#include "ofeedclient.h"
+#include "ofeedclientwidget.h"
+
+#include "../../eventplugin.h"
+
+#include <qf/qmlwidgets/framework/mainwindow.h>
+#include <qf/qmlwidgets/dialogs/dialog.h>
+
+#include <qf/core/log.h>
+#include <plugins/Runs/src/runsplugin.h>
+#include <plugins/Relays/src/relaysplugin.h>
+#include <quickevent/core/si/checkedcard.h>
+#include <qf/core/utils/htmlutils.h>
+#include <qf/core/sql/query.h>
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QHttpPart>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QSettings>
+#include <QStandardPaths>
+#include <QTextStream>
+#include <QTimer>
+#include <regex>
+
+namespace qfc = qf::core;
+namespace qfw = qf::qmlwidgets;
+namespace qfd = qf::qmlwidgets::dialogs;
+namespace qfs = qf::core::sql;
+using qf::qmlwidgets::framework::getPlugin;
+using Event::EventPlugin;
+using Relays::RelaysPlugin;
+using Runs::RunsPlugin;
+
+namespace Event {
+namespace services {
+
+OFeedClient::OFeedClient(QObject *parent)
+    : Super(OFeedClient::serviceName(), parent)
+{
+	m_networkManager = new QNetworkAccessManager(this);
+	m_exportTimer = new QTimer(this);
+    connect(m_exportTimer, &QTimer::timeout, this, &OFeedClient::onExportTimerTimeOut);
+    connect(this, &OFeedClient::settingsChanged, this, &OFeedClient::init, Qt::QueuedConnection);
+    connect(getPlugin<EventPlugin>(), &Event::EventPlugin::dbEventNotify, this, &OFeedClient::onDbEventNotify, Qt::QueuedConnection);
+}
+
+QString OFeedClient::serviceName()
+{
+    return QStringLiteral("OFeed");
+}
+
+void OFeedClient::run() {
+	Super::run();
+	exportStartListIofXml3([this](){exportResultsIofXml3();});
+	m_exportTimer->start();
+}
+
+void OFeedClient::stop() {
+	Super::stop();
+	m_exportTimer->stop();
+}
+
+void OFeedClient::exportResultsIofXml3()
+{
+	int current_stage = getPlugin<EventPlugin>()->currentStageId();
+	bool is_relays = getPlugin<EventPlugin>()->eventConfig()->isRelays();
+
+	QString str = is_relays
+			? getPlugin<RelaysPlugin>()->resultsIofXml30()
+			: getPlugin<RunsPlugin>()->resultsIofXml30Stage(current_stage);
+
+	sendFile("results upload", "/rest/v1/upload/iof", str);
+}
+
+void OFeedClient::exportStartListIofXml3(std::function<void()> on_success)
+{
+	int current_stage = getPlugin<EventPlugin>()->currentStageId();
+	bool is_relays = getPlugin<EventPlugin>()->eventConfig()->isRelays();
+
+	QString str = is_relays
+			? getPlugin<RelaysPlugin>()->startListIofXml30()
+			: getPlugin<RunsPlugin>()->startListStageIofXml30(current_stage);
+
+	sendFile("start list upload", "/rest/v1/upload/iof", str, on_success);
+}
+
+qf::qmlwidgets::framework::DialogWidget *OFeedClient::createDetailWidget()
+{
+    auto *w = new OFeedClientWidget();
+	return w;
+}
+
+void OFeedClient::init()
+{
+    OFeedClientSettings ss = settings();
+	m_exportTimer->setInterval(ss.exportIntervalSec() * 1000);
+}
+
+void OFeedClient::onExportTimerTimeOut()
+{
+	exportResultsIofXml3();
+}
+
+void OFeedClient::loadSettings()
+{
+	Super::loadSettings();
+	init();
+}
+
+void OFeedClient::sendFile(QString name, QString request_path, QString file, std::function<void()> on_success) {
+
+	QHttpMultiPart *multi_part = new QHttpMultiPart(QHttpMultiPart::FormDataType);
+
+	// Prepare the Authorization header with Bearer token
+	QString combined = eventId() + ":" + eventPassword();
+    QByteArray base64Auth = combined.toUtf8().toBase64();  // Base64 encode eventId:eventPassword
+	QString authValue = "Bearer " + QString(base64Auth);  // Bearer <base64_encoded_string>
+	QByteArray authHeader = authValue.toUtf8();
+
+	QHttpPart event_id_part;
+	event_id_part.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"eventId\""));
+	event_id_part.setBody(eventId().toUtf8());
+
+	QHttpPart file_part;
+	file_part.setHeader(QNetworkRequest::ContentTypeHeader, QVariant("application/zlib"));
+	file_part.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"file\""));
+	file_part.setBody(zlibCompress(file.toUtf8()));
+
+	multi_part->append(event_id_part);
+	multi_part->append(file_part);
+
+	QUrl url(hostUrl() + request_path);
+	QNetworkRequest request(url);
+    request.setRawHeader("Authorization", authHeader);
+	QNetworkReply *reply = m_networkManager->post(request, multi_part);
+	multi_part->setParent(reply);
+
+    connect(reply, &QNetworkReply::finished, this, [this, reply, name, on_success]()
+	{
+		if(reply->error()) {
+			auto err_msg = hostUrl() + " [" + name + "]: ";
+			auto response_body = reply->readAll();
+			if (!response_body.isEmpty())
+				err_msg += response_body + " | ";
+			qfError() << err_msg + reply->errorString();
+		}
+		else {
+			qfInfo() << hostUrl() + " [" + name + "]: success";
+			if (on_success)
+				on_success();
+		}
+		reply->deleteLater();
+	});
+}
+
+void OFeedClient::onDbEventNotify(const QString &domain, int connection_id, const QVariant &data)
+{
+    if (status() != Status::Running)
+        return;
+    Q_UNUSED(connection_id)
+    if(domain == QLatin1String(Event::EventPlugin::DBEVENT_CARD_PROCESSED_AND_ASSIGNED)) {
+        auto checked_card = quickevent::core::si::CheckedCard(data.toMap());
+        int competitor_id = getPlugin<RunsPlugin>()->competitorForRun(checked_card.runId());
+        onCompetitorChanged(competitor_id);
+    }
+    if(domain == QLatin1String(Event::EventPlugin::DBEVENT_COMPETITOR_EDITED)) {
+        int competitor_id = data.toInt();
+        onCompetitorChanged(competitor_id);
+    }
+}
+
+QString OFeedClient::hostUrl() const
+{
+    int current_stage = getPlugin<EventPlugin>()->currentStageId();
+    return getPlugin<EventPlugin>()->eventConfig()->value("ofeed.hostUrl.E" + QString::number(current_stage)).toString();
+}
+
+QString OFeedClient::eventId() const
+{
+    int current_stage = getPlugin<EventPlugin>()->currentStageId();
+    return getPlugin<EventPlugin>()->eventConfig()->value("ofeed.eventId.E" + QString::number(current_stage)).toString();
+}
+
+QString OFeedClient::eventPassword() const
+{
+    int current_stage = getPlugin<EventPlugin>()->currentStageId();
+    return getPlugin<EventPlugin>()->eventConfig()->value("ofeed.eventPassword.E" + QString::number(current_stage)).toString();
+}
+
+void OFeedClient::setHostUrl(QString hostUrl)
+{
+    int current_stage = getPlugin<EventPlugin>()->currentStageId();
+    getPlugin<EventPlugin>()->eventConfig()->setValue("ofeed.hostUrl.E" + QString::number(current_stage), hostUrl);
+    getPlugin<EventPlugin>()->eventConfig()->save("ofeed");
+}
+
+void OFeedClient::setEventId(QString eventId)
+{
+    int current_stage = getPlugin<EventPlugin>()->currentStageId();
+    getPlugin<EventPlugin>()->eventConfig()->setValue("ofeed.eventId.E" + QString::number(current_stage), eventId);
+    getPlugin<EventPlugin>()->eventConfig()->save("ofeed");
+}
+
+void OFeedClient::setEventPassword(QString eventPassword)
+{
+    int current_stage = getPlugin<EventPlugin>()->currentStageId();
+    getPlugin<EventPlugin>()->eventConfig()->setValue("ofeed.eventPassword.E" + QString::number(current_stage), eventPassword);
+    getPlugin<EventPlugin>()->eventConfig()->save("ofeed");
+}
+
+void OFeedClient::sendCompetitorChange(QString xml) {
+    QUrl url(hostUrl() + "/graphql");
+    QNetworkRequest request(url);
+    // request.setRawHeader("pwd", apiKey().toUtf8());
+    request.setHeader( QNetworkRequest::ContentTypeHeader, "application/zlib" );
+    QNetworkReply *reply = m_networkManager->post(request, zlibCompress(xml.toUtf8()));
+
+    connect(reply, &QNetworkReply::finished, this, [=]()
+    {
+        if(reply->error()) {
+            qfError() << "OFeed [competitor change]:" << reply->errorString();
+        }
+        else {
+            QString msg = reply->readAll();
+            if (msg.contains("BADPWD"))
+                qfError() << "OFeed [competitor change]: Invalid API key";
+            else if (!msg.contains("OK"))
+                qfError() << "OFeed [competitor change]: Failed to process request";
+        }
+        reply->deleteLater();
+    });
+}
+
+static void append_list(QVariantList &lst, const QVariantList &new_lst)
+{
+    lst.insert(lst.count(), new_lst);
+}
+
+static int mop_start(int runner_start_ms) {
+    int stage_id = getPlugin<EventPlugin>()->currentStageId();
+    QDateTime event_start = getPlugin<EventPlugin>()->stageStartDateTime(stage_id);
+    QDateTime runner_start = event_start.addMSecs(runner_start_ms);
+    return event_start.date().startOfDay().msecsTo(runner_start) / 100;
+}
+
+static int mop_run_status_code(
+		int time,
+		bool isDisq,
+		bool isDisqByOrganizer,
+		bool isMissPunch,
+		bool isBadCheck,
+		bool isDidNotStart,
+		bool isDidNotFinish,
+		bool isNotCompeting)
+{
+	if (isNotCompeting)
+		return 99; // NP (Not participating)
+	if (isMissPunch)
+		return 3; //MP (Missing punch)
+	if (isDidNotFinish)
+		return 4; // DNF (Did not finish)
+	if (isDidNotStart)
+		return 20; // DNS (Did not start)
+	if (isBadCheck || isDisqByOrganizer || isDisq)
+		return 5; // DQ (Disqualified)
+	if (time)
+		return 1; // OK
+	return 0; // Unknown
+}
+
+
+void OFeedClient::onCompetitorChanged(int competitor_id)
+{
+    if (competitor_id == 0)
+        return;
+
+    int stage_id = getPlugin<EventPlugin>()->currentStageId();
+    qf::core::sql::Query q;
+    q.exec("SELECT competitors.registration, "
+           "competitors.startNumber, "
+           "competitors.lastName || ' ' || competitors.firstName AS name, "
+           "classes.id AS classId, "
+           "runs.id AS runId, "
+           "runs.siId, "
+           "runs.disqualified, "
+           "runs.disqualifiedByOrganizer, "
+           "runs.misPunch, "
+           "runs.badCheck, "
+           "runs.notStart, "
+           "runs.notFinish, "
+           "runs.notCompeting, "
+           "runs.startTimeMs, "
+           "runs.finishTimeMs, "
+           "runs.timeMs "
+           "FROM runs "
+           "INNER JOIN competitors ON competitors.id = runs.competitorId "
+           "LEFT JOIN relays ON relays.id = runs.relayId  "
+           "INNER JOIN classes ON classes.id = competitors.classId OR classes.id = relays.classId  "
+           "WHERE competitors.id=" QF_IARG(competitor_id) " AND runs.stageId=" QF_IARG(stage_id), qf::core::Exception::Throw);
+    if(q.next()) {
+        int run_id = q.value("runId").toInt();
+        int start_num = q.value("startNumber").toInt();
+        QString name = q.value("name").toString();
+        QString class_id = q.value("classId").toString();
+        int card_num = q.value("siId").toInt();
+        bool isDisq = q.value("disqualified").toBool();
+        bool isDisqByOrganizer = q.value("disqualifiedByOrganizer").toBool();
+        bool isMissPunch = q.value("misPunch").toBool();
+        bool isBadCheck = q.value("badCheck").toBool();
+        bool isDidNotStart = q.value("notStart").toBool();
+        bool isDidNotFinish = q.value("notFinish").toBool();
+        bool isNotCompeting = q.value("notCompeting").toBool();
+        int start_time = q.value("startTimeMs").toInt();
+        int finish_time = q.value("finishTimeMs").toInt();
+        int running_time = q.value("timeMs").toInt();
+
+        int status_code = mop_run_status_code(running_time, isDisq, isDisqByOrganizer, isMissPunch, isBadCheck, isDidNotStart, isDidNotFinish, isNotCompeting);
+
+        QVariantMap competitor {
+            {"stat", status_code},
+            {"cls", class_id}
+        };
+        if (start_num != 0)
+            competitor.insert("bib", start_num);
+        if(start_time != 0)
+            competitor.insert("st", mop_start(start_time));
+        if(finish_time > start_time && running_time != 0)
+            competitor.insert("rt", running_time / 100);
+
+
+        QVariantList xml_root{"MOPDiff",
+            QVariantMap {
+                {"xmlns", "http://www.melin.nu/mop"},
+                {"creator", QStringLiteral("QuickEvent %1").arg(QCoreApplication::applicationVersion())},
+                {"createTime", QDateTime::currentDateTimeUtc().toString(Qt::ISODate)}
+            }
+        };
+        QVariantList xml_competitor{"cmp",
+            QVariantMap {
+                {"id", run_id },
+                {"card", card_num },
+            },
+            QVariantList {"base",
+                competitor,
+                name
+            }
+        };
+        append_list(xml_root, xml_competitor);
+        qf::core::utils::HtmlUtils::FromXmlListOptions opts;
+        opts.setDocumentTitle("Competitor change");
+        auto xml_paylaod = qf::core::utils::HtmlUtils::fromXmlList(xml_root, opts);
+        sendCompetitorChange(xml_paylaod);
+    }
+}
+
+QByteArray OFeedClient::zlibCompress(QByteArray data)
+{
+	QByteArray compressedData = qCompress(data);
+	// strip the 4-byte length put on by qCompress
+	// internally qCompress uses zlib
+	compressedData.remove(0, 4);
+	return compressedData;
+}
+}}

--- a/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclient.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclient.cpp
@@ -7,7 +7,10 @@
 #include <qf/qmlwidgets/dialogs/dialog.h>
 #include <qf/core/log.h>
 #include <qf/core/utils/htmlutils.h>
+
+#include <qf/core/sql/connection.h>
 #include <qf/core/sql/query.h>
+#include <qf/core/sql/transaction.h>
 
 #include <plugins/Runs/src/runsplugin.h>
 #include <plugins/Relays/src/relaysplugin.h>
@@ -32,6 +35,7 @@
 #include <sstream>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QSet>
 
 namespace qfc = qf::core;
 namespace qfw = qf::qmlwidgets;
@@ -147,8 +151,8 @@ namespace Event
             multi_part->append(file_part);
 
             // Create network request with authorization header
-            QUrl url(hostUrl() + request_path);
-            QNetworkRequest request(url);
+            QUrl request_url(hostUrl() + request_path);
+            QNetworkRequest request(request_url);
             request.setRawHeader("Authorization", auth_header);
 
             // Send request
@@ -156,17 +160,17 @@ namespace Event
             multi_part->setParent(reply);
 
             // Cleanup
-            connect(reply, &QNetworkReply::finished, this, [this, reply, name, on_success]()
+            connect(reply, &QNetworkReply::finished, this, [this, reply, name, request_url, on_success]()
                     {
 		if(reply->error()) {
-			auto err_msg = hostUrl() + " [" + name + "]: ";
+			auto err_msg = "OFeed [" + name + "] " + request_url.toString() + " : ";
 			auto response_body = reply->readAll();
 			if (!response_body.isEmpty())
 				err_msg += response_body + " | ";
 			qfError() << err_msg + reply->errorString();
 		}
 		else {
-			qfInfo() << "OFeed " + hostUrl() + " [" + name + "]: success";
+			qfInfo() << "OFeed [" + name + "]: ok";
 			if (on_success)
 				on_success();
 		}
@@ -186,10 +190,26 @@ namespace Event
             }
             if (domain == QLatin1String(Event::EventPlugin::DBEVENT_COMPETITOR_EDITED))
             {
+                // TODO: use event DBEVENT_COMPETITOR_COUNTS_CHANGED - edit + count change -> new or deleted
                 int competitor_id = data.toInt();
                 onCompetitorEdited(competitor_id);
             }
         }
+
+        // void OFeedClient::getChangesFromStart(){
+            // TODO
+            // Get changes
+            // Update the database with changed values
+            // qf::core::sql::Query q(sqlModel()->connectionName());
+			// 		q.prepare("UPDATE runs SET siId=:siId WHERE competitorId=:competitorId", qf::core::Exception::Throw);
+			// 		q.bindValue(":competitorId", competitor_id);
+			// 		q.bindValue(":siId", siid());
+			// 		q.exec(qf::core::Exception::Throw);
+            // https://github.com/Quick-Box/quickevent/blob/master/quickevent/app/quickevent/plugins/Event/src/eventplugin.cpp#L434
+            // https://github.com/Quick-Box/quickevent/blob/master/quickevent/app/quickevent/plugins/Competitors/src/competitorwidget.cpp#L191
+            // Save them in the config table
+            // Display the processed records in the table
+        // }
 
         QString OFeedClient::hostUrl() const
         {
@@ -230,7 +250,7 @@ namespace Event
             getPlugin<EventPlugin>()->eventConfig()->save("ofeed");
         }
 
-        void OFeedClient::sendCompetitorChange(QString jsonBody, int competitor_id)
+        void OFeedClient::sendCompetitorChange(QString json_body, int competitor_id)
         {
             // Prepare the Authorization header base64 username:password
             QString combined = eventId() + ":" + eventPassword();
@@ -247,7 +267,7 @@ namespace Event
             request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
 
             // Send request
-            QNetworkReply *reply = m_networkManager->put(request, jsonBody.toUtf8());
+            QNetworkReply *reply = m_networkManager->put(request, json_body.toUtf8());
 
             connect(reply, &QNetworkReply::finished, this, [=]()
                     {
@@ -265,12 +285,58 @@ namespace Event
                 
                 if (data_object.contains("message")) {
                     QString data_message = data_object["message"].toString();
-                    qfInfo() << "OFeed [competitor change] Success:" << data_message;
+                    qfInfo() << "OFeed [competitor change]:" << data_message;
                 } else {
-                    qfInfo() << "OFeed [competitor change] Success but no data message found.";
+                    qfInfo() << "OFeed [competitor change]: ok, but no data message found.";
                 }
             } else {
                 qfError() << "OFeed [competitor change] Unexpected response:" << response;
+            }
+        }
+        reply->deleteLater(); });
+        }
+
+        void OFeedClient::sendNewCompetitor(QString json_body)
+        {
+            // Prepare the Authorization header base64 username:password
+            QString combined = eventId() + ":" + eventPassword();
+            QByteArray base_64_auth = combined.toUtf8().toBase64();
+            QString auth_value = "Basic " + QString(base_64_auth);
+            QByteArray auth_header = auth_value.toUtf8();
+
+            // Create the URL for the POST request
+            QUrl url(hostUrl() + "/rest/v1/events/" + eventId() + "/competitors");
+            
+            // Create the network request
+            QNetworkRequest request(url);
+            request.setRawHeader("Authorization", auth_header);
+            request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+
+            // Send request
+            QNetworkReply *reply = m_networkManager->post(request, json_body.toUtf8());
+
+            connect(reply, &QNetworkReply::finished, this, [=]()
+                    {
+        if(reply->error()) {
+            qfError() << "OFeed [new competitor]:" << reply->errorString();
+        }
+        else {
+            QByteArray response = reply->readAll();
+            QJsonDocument json_response = QJsonDocument::fromJson(response);
+            QJsonObject json_object = json_response.object();
+
+            if (json_object.contains("error") && !json_object["error"].toBool()) {
+                QJsonObject results_object = json_object["results"].toObject();
+                QJsonObject data_object = results_object["data"].toObject();
+                
+                if (data_object.contains("message")) {
+                    QString data_message = data_object["message"].toString();
+                    qfInfo() << "OFeed [new competitor]:" << data_message;
+                } else {
+                    qfInfo() << "OFeed [new competitor]: ok, but no data message found.";
+                }
+            } else {
+                qfError() << "OFeed [new competitor] Unexpected response:" << response;
             }
         }
         reply->deleteLater(); });
@@ -286,6 +352,10 @@ namespace Event
             bool is_did_not_finish,
             bool is_not_competing)
         {
+            // Handle time initial value
+            if (time == -1){
+                return "Inactive";
+            }
             // IOF xml 3.0 statuses:
             // OK (finished and validated)
             // Finished (finished but not yet validated.)
@@ -310,7 +380,7 @@ namespace Event
                 return "Disqualified";
             if (time)
                 return "OK"; // OK
-            return 0;     // Unknown
+            return "Inactive"; // Inactive as default status
         }
 
         static QString datetime_to_string(const QDateTime &dt)
@@ -320,8 +390,35 @@ namespace Event
 
         void OFeedClient::onCompetitorEdited(int competitor_id)
         {
-            if (competitor_id == 0)
+            if (competitor_id == 0){
                 return;
+            }
+            bool update_competitor = true;
+            // Handle a new competitor - use the value of the sequence and check current value?
+            // TODO: fix schema name
+            // qf::core::sql::Connection::forName();
+            // qf::core::utils::ConfigCLIOptions
+            // cliOptions()->eventName()
+            qf::core::sql::Query q_schema;
+            q_schema.exec("select current_schema", qf::core::Exception::Throw);
+            if (q_schema.next()) {
+                QString qe_event_id = q_schema.value(0).toString();
+
+                // Query actual competitor id
+                qf::core::sql::Query q_seq_comp;
+                q_seq_comp.exec("SELECT last_value FROM pg_sequences WHERE schemaname = '" + qe_event_id + "' AND sequencename = 'competitors_id_seq'", qf::core::Exception::Throw);
+                if (q_seq_comp.next()){
+                    int actual_seq_competitors_value = q_seq_comp.value(QStringLiteral("last_value")).toInt();
+                    
+                    // Check if a new competitor was inserted
+                    // if (actual_seq_competitors_value == competitor_id && domain == QLatin1String(Event::EventPlugin::DBEVENT_COMPETITOR_COUNTS_CHANGED)){
+                    if (actual_seq_competitors_value == competitor_id){
+                        update_competitor = false;
+                    }
+                }
+            }
+                
+            int INT_INITIAL_VALUE = -1;
 
             int stage_id = getPlugin<EventPlugin>()->currentStageId();
             QDateTime stage_start_date_time = getPlugin<EventPlugin>()->stageStartDateTime(stage_id);
@@ -330,6 +427,8 @@ namespace Event
                    "competitors.startNumber, "
                    "competitors.firstName, "
                    "competitors.lastName, "
+                   "clubs.name AS organisationName, "
+                   "clubs.abbr AS organisationAbbr, "
                    "classes.id AS classId, "
                    "runs.id AS runId, "
                    "runs.siId, "
@@ -346,18 +445,58 @@ namespace Event
                    "FROM runs "
                    "INNER JOIN competitors ON competitors.id = runs.competitorId "
                    "LEFT JOIN relays ON relays.id = runs.relayId  "
+                   "LEFT JOIN clubs ON substr(competitors.registration, 1, 3) = clubs.abbr "
                    "INNER JOIN classes ON classes.id = competitors.classId OR classes.id = relays.classId  "
                    "WHERE competitors.id=" QF_IARG(competitor_id) " AND runs.stageId=" QF_IARG(stage_id),
                    qf::core::Exception::Throw);
             if (q.next())
             {
-                // int run_id = q.value("runId").toInt();
-                int start_bib = q.value(QStringLiteral("startNumber")).toInt();
+                QString registration = q.value(QStringLiteral("registration")).toString();
                 QString first_name = q.value(QStringLiteral("firstName")).toString();
                 QString last_name = q.value(QStringLiteral("lastName")).toString();
-                QString registration = q.value(QStringLiteral("registration")).toString();
-                QString class_id = q.value(QStringLiteral("classId")).toString();
                 int card_number = q.value(QStringLiteral("siId")).toInt();
+                QString organisation_name = q.value(QStringLiteral("organisationName")).toString();
+                QString organisation_abbr = q.value(QStringLiteral("organisationAbbr")).toString();
+                QString organisation = !organisation_abbr.isEmpty() ? organisation_name : registration.left(3);
+                int class_id = q.value(QStringLiteral("classId")).toInt();
+                QString nationality = "";
+                // int run_id = q.value("runId").toInt();
+                QString origin = "IT";
+                QString note = "Edited from Quickevent";
+
+                // Start bib
+                int start_bib = INT_INITIAL_VALUE;
+                QVariant start_bib_variant = q.value(QStringLiteral("startNumber"));
+                if (!start_bib_variant.isNull())
+                {
+                    start_bib = start_bib_variant.toInt();
+                }                
+
+                // Start time
+                int start_time = INT_INITIAL_VALUE;
+                QVariant start_time_variant = q.value(QStringLiteral("startTimeMs"));
+                if (!start_time_variant.isNull())
+                {
+                    start_time = start_time_variant.toInt();
+                }
+
+                // Finish time
+                int finish_time = INT_INITIAL_VALUE;
+                QVariant finish_time_variant = q.value(QStringLiteral("finishTimeMs"));
+                if (!finish_time_variant.isNull())
+                {
+                    finish_time = finish_time_variant.toInt();
+                }
+
+                // Time
+                int running_time = INT_INITIAL_VALUE;
+                QVariant running_time_variant = q.value(QStringLiteral("timeMs"));
+                if (!running_time_variant.isNull())
+                {
+                    running_time = running_time_variant.toInt();
+                }
+
+                // Status
                 bool is_disq = q.value(QStringLiteral("disqualified")).toBool();
                 bool is_disq_by_organizer = q.value(QStringLiteral("disqualifiedByOrganizer")).toBool();
                 bool is_miss_punch = q.value(QStringLiteral("misPunch")).toBool();
@@ -365,33 +504,79 @@ namespace Event
                 bool is_did_not_start = q.value(QStringLiteral("notStart")).toBool();
                 bool is_did_not_finish = q.value(QStringLiteral("notFinish")).toBool();
                 bool is_not_competing = q.value(QStringLiteral("notCompeting")).toBool();
-                int start_time = q.value(QStringLiteral("startTimeMs")).toInt();
-                int finish_time = q.value(QStringLiteral("finishTimeMs")).toInt();
-                int running_time = q.value(QStringLiteral("timeMs")).toInt();
                 QString status = getIofResultStatus(running_time, is_disq, is_disq_by_organizer, is_miss_punch, is_bad_check, is_did_not_start, is_did_not_finish, is_not_competing);
-                QString origin = "IT";
-                QString note = "Edited from Quickevent";
+                
+                if(!update_competitor){
+                    status="Inactive";
+                }
 
                 // Use std::stringstream to build the JSON string
                 std::stringstream json_payload;
+
+                // Setup common values
                 json_payload << "{"
-                             << "\"useExternalId\":true,"
-                             << "\"classExternalId\":\"" << class_id.toStdString() << "\","
-                             << "\"origin\":\"" << origin.toStdString() << "\","
-                             << "\"firstname\":\"" << first_name.toStdString() << "\","
-                             << "\"lastname\":\"" << last_name.toStdString() << "\","
-                             << "\"registration\":\"" << registration.toStdString() << "\","
-                             << "\"bibNumber\":" << start_bib << ","
-                             << "\"card\":" << card_number << ","
-                             << "\"startTime\":\"" << datetime_to_string(stage_start_date_time.addMSecs(start_time)).toStdString() << "\","
-                             << "\"finishTime\":\"" << datetime_to_string(stage_start_date_time.addMSecs(finish_time)).toStdString() << "\","
-                             << "\"time\":" << running_time << ","
-                             << "\"status\":\"" << status.toStdString() << "\","
-                             << "\"note\":\"" << note.toStdString() << "\""
-                             << "}";
+                << "\"origin\":\"" << origin.toStdString() << "\","
+                << "\"firstname\":\"" << first_name.toStdString() << "\","
+                << "\"lastname\":\"" << last_name.toStdString() << "\","
+                << "\"registration\":\"" << registration.toStdString() << "\","
+                << "\"organisation\":\"" << organisation.toStdString() << "\","               
+                << "\"status\":\"" << status.toStdString() << "\","
+                << "\"note\":\"" << note.toStdString() << "\",";
+
+                if (nationality != ""){
+                    json_payload << "\"nationality\":\"" << nationality.toStdString() << "\",";
+                }
+                
+                // New competitor
+                if(!update_competitor){
+                    json_payload<< "\"classExternalId\":\"" << class_id << "\","
+                                << "\"externalId\":\"" << competitor_id << "\",";
+                }
+                // Update existing competitor
+                else{
+                    json_payload<< "\"useExternalId\":true,"
+                                << "\"classExternalId\":\"" << class_id<< "\",";
+
+                }
+                // Card number - QE saves 0 for empty si card
+                if(card_number != 0){
+                    json_payload << "\"card\":" << card_number << ",";
+                }
+                
+                // Finish time
+                if (finish_time != INT_INITIAL_VALUE)
+                {
+                    json_payload << "\"finishTime\":\"" << datetime_to_string(stage_start_date_time.addMSecs(finish_time)).toStdString() << "\",";
+                }
+
+                // Star time
+                if (start_time != INT_INITIAL_VALUE)
+                {
+                    json_payload << "\"startTime\":\"" << datetime_to_string(stage_start_date_time.addMSecs(start_time)).toStdString() << "\",";
+                }
+
+                // Start bib
+                if (start_bib != INT_INITIAL_VALUE)
+                {
+                    json_payload << "\"bibNumber\":" << start_bib << ",";
+                }
+
+                //  Competitor's time
+                if (running_time != INT_INITIAL_VALUE)
+                {
+                    json_payload << "\"time\":" << running_time << ",";
+                }
 
                 // Get the final JSON string
                 std::string json_str = json_payload.str();
+
+                // Remove the trailing comma if necessary
+                if (json_str.back() == ',')
+                {
+                    json_str.pop_back();
+                }
+
+                json_str += "}";
 
                 // Output the JSON for debugging
                 std::cout << "JSON Payload: " << json_str << std::endl;
@@ -399,9 +584,15 @@ namespace Event
                 // Convert std::string to QString
                 QString json_qstr = QString::fromStdString(json_str);
 
-                sendCompetitorChange(json_qstr, competitor_id);
+                // Send only a new competitor with start time (E1 button click calls db event which should be skipped=start time is not set)
+                if(!update_competitor && start_time != INT_INITIAL_VALUE){
+                    sendNewCompetitor(json_qstr);
+                }else if (update_competitor && start_time != INT_INITIAL_VALUE){
+                    sendCompetitorChange(json_qstr, competitor_id);
+                }
             }
         }
+        
         void OFeedClient::onCompetitorReadOut(int competitor_id)
         {
             if (competitor_id == 0)
@@ -449,7 +640,7 @@ namespace Event
                              << "\"origin\":\"" << origin.toStdString() << "\","
                              << "\"startTime\":\"" << datetime_to_string(stage_start_date_time.addMSecs(start_time)).toStdString() << "\","
                              << "\"finishTime\":\"" << datetime_to_string(stage_start_date_time.addMSecs(finish_time)).toStdString() << "\","
-                             << "\"time\":" << running_time << ","
+                             << "\"time\":" << running_time/1000 << ","
                              << "\"status\":\"" << status.toStdString() << "\","
                              << "\"note\":\"" << note.toStdString() << "\""
                              << "}";

--- a/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclient.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclient.cpp
@@ -5,13 +5,15 @@
 
 #include <qf/qmlwidgets/framework/mainwindow.h>
 #include <qf/qmlwidgets/dialogs/dialog.h>
-
 #include <qf/core/log.h>
-#include <plugins/Runs/src/runsplugin.h>
-#include <plugins/Relays/src/relaysplugin.h>
-#include <quickevent/core/si/checkedcard.h>
 #include <qf/core/utils/htmlutils.h>
 #include <qf/core/sql/query.h>
+
+#include <plugins/Runs/src/runsplugin.h>
+#include <plugins/Relays/src/relaysplugin.h>
+
+#include <quickevent/core/si/checkedcard.h>
+#include <quickevent/core/utils.h>
 
 #include <QCoreApplication>
 #include <QDir>
@@ -23,127 +25,139 @@
 #include <QStandardPaths>
 #include <QTextStream>
 #include <QTimer>
+#include <QDateTime>
+#include <QTimeZone>
 #include <regex>
+#include <iostream>
+#include <sstream>
+#include <QJsonDocument>
+#include <QJsonObject>
 
 namespace qfc = qf::core;
 namespace qfw = qf::qmlwidgets;
 namespace qfd = qf::qmlwidgets::dialogs;
 namespace qfs = qf::core::sql;
-using qf::qmlwidgets::framework::getPlugin;
 using Event::EventPlugin;
+using qf::qmlwidgets::framework::getPlugin;
 using Relays::RelaysPlugin;
 using Runs::RunsPlugin;
 
-namespace Event {
-namespace services {
-
-OFeedClient::OFeedClient(QObject *parent)
-    : Super(OFeedClient::serviceName(), parent)
+namespace Event
 {
-	m_networkManager = new QNetworkAccessManager(this);
-	m_exportTimer = new QTimer(this);
-    connect(m_exportTimer, &QTimer::timeout, this, &OFeedClient::onExportTimerTimeOut);
-    connect(this, &OFeedClient::settingsChanged, this, &OFeedClient::init, Qt::QueuedConnection);
-    connect(getPlugin<EventPlugin>(), &Event::EventPlugin::dbEventNotify, this, &OFeedClient::onDbEventNotify, Qt::QueuedConnection);
-}
+    namespace services
+    {
 
-QString OFeedClient::serviceName()
-{
-    return QStringLiteral("OFeed");
-}
+        OFeedClient::OFeedClient(QObject *parent)
+            : Super(OFeedClient::serviceName(), parent)
+        {
+            m_networkManager = new QNetworkAccessManager(this);
+            m_exportTimer = new QTimer(this);
+            connect(m_exportTimer, &QTimer::timeout, this, &OFeedClient::onExportTimerTimeOut);
+            connect(this, &OFeedClient::settingsChanged, this, &OFeedClient::init, Qt::QueuedConnection);
+            connect(getPlugin<EventPlugin>(), &Event::EventPlugin::dbEventNotify, this, &OFeedClient::onDbEventNotify, Qt::QueuedConnection);
+        }
 
-void OFeedClient::run() {
-	Super::run();
-	exportStartListIofXml3([this](){exportResultsIofXml3();});
-	m_exportTimer->start();
-}
+        QString OFeedClient::serviceName()
+        {
+            return QStringLiteral("OFeed");
+        }
 
-void OFeedClient::stop() {
-	Super::stop();
-	m_exportTimer->stop();
-}
+        void OFeedClient::run()
+        {
+            Super::run();
+            exportStartListIofXml3([this]()
+                                   { exportResultsIofXml3(); });
+            m_exportTimer->start();
+        }
 
-void OFeedClient::exportResultsIofXml3()
-{
-	int current_stage = getPlugin<EventPlugin>()->currentStageId();
-	bool is_relays = getPlugin<EventPlugin>()->eventConfig()->isRelays();
+        void OFeedClient::stop()
+        {
+            Super::stop();
+            m_exportTimer->stop();
+        }
 
-	QString str = is_relays
-			? getPlugin<RelaysPlugin>()->resultsIofXml30()
-			: getPlugin<RunsPlugin>()->resultsIofXml30Stage(current_stage);
+        void OFeedClient::exportResultsIofXml3()
+        {
+            int current_stage = getPlugin<EventPlugin>()->currentStageId();
+            bool is_relays = getPlugin<EventPlugin>()->eventConfig()->isRelays();
 
-	sendFile("results upload", "/rest/v1/upload/iof", str);
-}
+            QString str = is_relays
+                              ? getPlugin<RelaysPlugin>()->resultsIofXml30()
+                              : getPlugin<RunsPlugin>()->resultsIofXml30Stage(current_stage);
 
-void OFeedClient::exportStartListIofXml3(std::function<void()> on_success)
-{
-	int current_stage = getPlugin<EventPlugin>()->currentStageId();
-	bool is_relays = getPlugin<EventPlugin>()->eventConfig()->isRelays();
+            sendFile("results upload", "/rest/v1/upload/iof", str);
+        }
 
-	QString str = is_relays
-			? getPlugin<RelaysPlugin>()->startListIofXml30()
-			: getPlugin<RunsPlugin>()->startListStageIofXml30(current_stage);
+        void OFeedClient::exportStartListIofXml3(std::function<void()> on_success)
+        {
+            int current_stage = getPlugin<EventPlugin>()->currentStageId();
+            bool is_relays = getPlugin<EventPlugin>()->eventConfig()->isRelays();
 
-	sendFile("start list upload", "/rest/v1/upload/iof", str, on_success);
-}
+            QString str = is_relays
+                              ? getPlugin<RelaysPlugin>()->startListIofXml30()
+                              : getPlugin<RunsPlugin>()->startListStageIofXml30(current_stage);
 
-qf::qmlwidgets::framework::DialogWidget *OFeedClient::createDetailWidget()
-{
-    auto *w = new OFeedClientWidget();
-	return w;
-}
+            sendFile("start list upload", "/rest/v1/upload/iof", str, on_success);
+        }
 
-void OFeedClient::init()
-{
-    OFeedClientSettings ss = settings();
-	m_exportTimer->setInterval(ss.exportIntervalSec() * 1000);
-}
+        qf::qmlwidgets::framework::DialogWidget *OFeedClient::createDetailWidget()
+        {
+            auto *w = new OFeedClientWidget();
+            return w;
+        }
 
-void OFeedClient::onExportTimerTimeOut()
-{
-	exportResultsIofXml3();
-}
+        void OFeedClient::init()
+        {
+            OFeedClientSettings ss = settings();
+            m_exportTimer->setInterval(ss.exportIntervalSec() * 1000);
+        }
 
-void OFeedClient::loadSettings()
-{
-	Super::loadSettings();
-	init();
-}
+        void OFeedClient::onExportTimerTimeOut()
+        {
+            exportResultsIofXml3();
+        }
 
-void OFeedClient::sendFile(QString name, QString request_path, QString file, std::function<void()> on_success) {
-     // Create a multi-part request (like FormData in JS)
-	QHttpMultiPart *multi_part = new QHttpMultiPart(QHttpMultiPart::FormDataType);
+        void OFeedClient::loadSettings()
+        {
+            Super::loadSettings();
+            init();
+        }
 
-	// Prepare the Authorization header with Bearer token
-	QString combined = eventId() + ":" + eventPassword();
-    QByteArray base_64_auth = combined.toUtf8().toBase64();
-	QString auth_value = "Bearer " + QString(base_64_auth);
-	QByteArray auth_header = auth_value.toUtf8();
+        void OFeedClient::sendFile(QString name, QString request_path, QString file, std::function<void()> on_success)
+        {
+            // Create a multi-part request (like FormData in JS)
+            QHttpMultiPart *multi_part = new QHttpMultiPart(QHttpMultiPart::FormDataType);
 
-    // Add eventId field
-	QHttpPart event_id_part;
-	event_id_part.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"eventId\""));
-	event_id_part.setBody(eventId().toUtf8());
-	multi_part->append(event_id_part);
+            // Prepare the Authorization header with Bearer token
+            QString combined = eventId() + ":" + eventPassword();
+            QByteArray base_64_auth = combined.toUtf8().toBase64();
+            QString auth_value = "Basic " + QString(base_64_auth);
+            QByteArray auth_header = auth_value.toUtf8();
 
-    // Add xml content with fake filename that must be present
-	QHttpPart file_part;
-    file_part.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"file\"; filename=\"uploaded_file.xml\""));
-	file_part.setBody(file.toUtf8());
-	multi_part->append(file_part);
+            // Add eventId field
+            QHttpPart event_id_part;
+            event_id_part.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"eventId\""));
+            event_id_part.setBody(eventId().toUtf8());
+            multi_part->append(event_id_part);
 
-    // Create network request with authorization header
-	QUrl url(hostUrl() + request_path);
-	QNetworkRequest request(url);
-    request.setRawHeader("Authorization", auth_header);
+            // Add xml content with fake filename that must be present
+            QHttpPart file_part;
+            file_part.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"file\"; filename=\"uploaded_file.xml\""));
+            file_part.setBody(file.toUtf8());
+            multi_part->append(file_part);
 
-    // Send request
-	QNetworkReply *reply = m_networkManager->post(request, multi_part);
-	multi_part->setParent(reply);
+            // Create network request with authorization header
+            QUrl url(hostUrl() + request_path);
+            QNetworkRequest request(url);
+            request.setRawHeader("Authorization", auth_header);
 
-    // Cleanup
-    connect(reply, &QNetworkReply::finished, this, [this, reply, name, on_success]()
-	{
+            // Send request
+            QNetworkReply *reply = m_networkManager->post(request, multi_part);
+            multi_part->setParent(reply);
+
+            // Cleanup
+            connect(reply, &QNetworkReply::finished, this, [this, reply, name, on_success]()
+                    {
 		if(reply->error()) {
 			auto err_msg = hostUrl() + " [" + name + "]: ";
 			auto response_body = reply->readAll();
@@ -152,220 +166,305 @@ void OFeedClient::sendFile(QString name, QString request_path, QString file, std
 			qfError() << err_msg + reply->errorString();
 		}
 		else {
-			qfInfo() << hostUrl() + " [" + name + "]: success";
+			qfInfo() << "OFeed " + hostUrl() + " [" + name + "]: success";
 			if (on_success)
 				on_success();
 		}
-		reply->deleteLater();
-	});
-}
+		reply->deleteLater(); });
+        }
 
-void OFeedClient::onDbEventNotify(const QString &domain, int connection_id, const QVariant &data)
-{
-    if (status() != Status::Running)
-        return;
-    Q_UNUSED(connection_id)
-    if(domain == QLatin1String(Event::EventPlugin::DBEVENT_CARD_PROCESSED_AND_ASSIGNED)) {
-        auto checked_card = quickevent::core::si::CheckedCard(data.toMap());
-        int competitor_id = getPlugin<RunsPlugin>()->competitorForRun(checked_card.runId());
-        onCompetitorChanged(competitor_id);
-    }
-    if(domain == QLatin1String(Event::EventPlugin::DBEVENT_COMPETITOR_EDITED)) {
-        int competitor_id = data.toInt();
-        onCompetitorChanged(competitor_id);
-    }
-}
+        void OFeedClient::onDbEventNotify(const QString &domain, int connection_id, const QVariant &data)
+        {
+            if (status() != Status::Running)
+                return;
+            Q_UNUSED(connection_id)
+            if (domain == QLatin1String(Event::EventPlugin::DBEVENT_CARD_PROCESSED_AND_ASSIGNED))
+            {
+                auto checked_card = quickevent::core::si::CheckedCard(data.toMap());
+                int competitor_id = getPlugin<RunsPlugin>()->competitorForRun(checked_card.runId());
+                onCompetitorReadOut(competitor_id);
+            }
+            if (domain == QLatin1String(Event::EventPlugin::DBEVENT_COMPETITOR_EDITED))
+            {
+                int competitor_id = data.toInt();
+                onCompetitorEdited(competitor_id);
+            }
+        }
 
-QString OFeedClient::hostUrl() const
-{
-    int current_stage = getPlugin<EventPlugin>()->currentStageId();
-    return getPlugin<EventPlugin>()->eventConfig()->value("ofeed.hostUrl.E" + QString::number(current_stage)).toString();
-}
+        QString OFeedClient::hostUrl() const
+        {
+            int current_stage = getPlugin<EventPlugin>()->currentStageId();
+            return getPlugin<EventPlugin>()->eventConfig()->value("ofeed.hostUrl.E" + QString::number(current_stage)).toString();
+        }
 
-QString OFeedClient::eventId() const
-{
-    int current_stage = getPlugin<EventPlugin>()->currentStageId();
-    return getPlugin<EventPlugin>()->eventConfig()->value("ofeed.eventId.E" + QString::number(current_stage)).toString();
-}
+        QString OFeedClient::eventId() const
+        {
+            int current_stage = getPlugin<EventPlugin>()->currentStageId();
+            return getPlugin<EventPlugin>()->eventConfig()->value("ofeed.eventId.E" + QString::number(current_stage)).toString();
+        }
 
-QString OFeedClient::eventPassword() const
-{
-    int current_stage = getPlugin<EventPlugin>()->currentStageId();
-    return getPlugin<EventPlugin>()->eventConfig()->value("ofeed.eventPassword.E" + QString::number(current_stage)).toString();
-}
+        QString OFeedClient::eventPassword() const
+        {
+            int current_stage = getPlugin<EventPlugin>()->currentStageId();
+            return getPlugin<EventPlugin>()->eventConfig()->value("ofeed.eventPassword.E" + QString::number(current_stage)).toString();
+        }
 
-void OFeedClient::setHostUrl(QString hostUrl)
-{
-    int current_stage = getPlugin<EventPlugin>()->currentStageId();
-    getPlugin<EventPlugin>()->eventConfig()->setValue("ofeed.hostUrl.E" + QString::number(current_stage), hostUrl);
-    getPlugin<EventPlugin>()->eventConfig()->save("ofeed");
-}
+        void OFeedClient::setHostUrl(QString hostUrl)
+        {
+            int current_stage = getPlugin<EventPlugin>()->currentStageId();
+            getPlugin<EventPlugin>()->eventConfig()->setValue("ofeed.hostUrl.E" + QString::number(current_stage), hostUrl);
+            getPlugin<EventPlugin>()->eventConfig()->save("ofeed");
+        }
 
-void OFeedClient::setEventId(QString eventId)
-{
-    int current_stage = getPlugin<EventPlugin>()->currentStageId();
-    getPlugin<EventPlugin>()->eventConfig()->setValue("ofeed.eventId.E" + QString::number(current_stage), eventId);
-    getPlugin<EventPlugin>()->eventConfig()->save("ofeed");
-}
+        void OFeedClient::setEventId(QString eventId)
+        {
+            int current_stage = getPlugin<EventPlugin>()->currentStageId();
+            getPlugin<EventPlugin>()->eventConfig()->setValue("ofeed.eventId.E" + QString::number(current_stage), eventId);
+            getPlugin<EventPlugin>()->eventConfig()->save("ofeed");
+        }
 
-void OFeedClient::setEventPassword(QString eventPassword)
-{
-    int current_stage = getPlugin<EventPlugin>()->currentStageId();
-    getPlugin<EventPlugin>()->eventConfig()->setValue("ofeed.eventPassword.E" + QString::number(current_stage), eventPassword);
-    getPlugin<EventPlugin>()->eventConfig()->save("ofeed");
-}
+        void OFeedClient::setEventPassword(QString eventPassword)
+        {
+            int current_stage = getPlugin<EventPlugin>()->currentStageId();
+            getPlugin<EventPlugin>()->eventConfig()->setValue("ofeed.eventPassword.E" + QString::number(current_stage), eventPassword);
+            getPlugin<EventPlugin>()->eventConfig()->save("ofeed");
+        }
 
-void OFeedClient::sendCompetitorChange(QString xml) {
-    QUrl url(hostUrl() + "/graphql");
-    QNetworkRequest request(url);
-    // request.setRawHeader("pwd", apiKey().toUtf8());
-    request.setHeader( QNetworkRequest::ContentTypeHeader, "application/zlib" );
-    QNetworkReply *reply = m_networkManager->post(request, zlibCompress(xml.toUtf8()));
+        void OFeedClient::sendCompetitorChange(QString jsonBody, int competitor_id)
+        {
+            // Prepare the Authorization header base64 username:password
+            QString combined = eventId() + ":" + eventPassword();
+            QByteArray base_64_auth = combined.toUtf8().toBase64();
+            QString auth_value = "Basic " + QString(base_64_auth);
+            QByteArray auth_header = auth_value.toUtf8();
 
-    connect(reply, &QNetworkReply::finished, this, [=]()
-    {
+            // Create the URL for the PUT request
+            QUrl url(hostUrl() + "/rest/v1/events/" + eventId() + "/competitors/" + QString::number(competitor_id) + "/external-id");
+            
+            // Create the network request
+            QNetworkRequest request(url);
+            request.setRawHeader("Authorization", auth_header);
+            request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+
+            // Send request
+            QNetworkReply *reply = m_networkManager->put(request, jsonBody.toUtf8());
+
+            connect(reply, &QNetworkReply::finished, this, [=]()
+                    {
         if(reply->error()) {
             qfError() << "OFeed [competitor change]:" << reply->errorString();
         }
         else {
-            QString msg = reply->readAll();
-            if (msg.contains("BADPWD"))
-                qfError() << "OFeed [competitor change]: Invalid API key";
-            else if (!msg.contains("OK"))
-                qfError() << "OFeed [competitor change]: Failed to process request";
+            QByteArray response = reply->readAll();
+            QJsonDocument json_response = QJsonDocument::fromJson(response);
+            QJsonObject json_object = json_response.object();
+
+            if (json_object.contains("error") && !json_object["error"].toBool()) {
+                QJsonObject results_object = json_object["results"].toObject();
+                QJsonObject data_object = results_object["data"].toObject();
+                
+                if (data_object.contains("message")) {
+                    QString data_message = data_object["message"].toString();
+                    qfInfo() << "OFeed [competitor change] Success:" << data_message;
+                } else {
+                    qfInfo() << "OFeed [competitor change] Success but no data message found.";
+                }
+            } else {
+                qfError() << "OFeed [competitor change] Unexpected response:" << response;
+            }
         }
-        reply->deleteLater();
-    });
-}
+        reply->deleteLater(); });
+        }
 
-static void append_list(QVariantList &lst, const QVariantList &new_lst)
-{
-    lst.insert(lst.count(), new_lst);
-}
+        static QString getIofResultStatus(
+            int time,
+            bool is_disq,
+            bool is_disq_by_organizer,
+            bool is_miss_punch,
+            bool is_bad_check,
+            bool is_did_not_start,
+            bool is_did_not_finish,
+            bool is_not_competing)
+        {
+            // IOF xml 3.0 statuses:
+            // OK (finished and validated)
+            // Finished (finished but not yet validated.)
+            // MissingPunch
+            // Disqualified (for some other reason than a missing punch)
+            // DidNotFinish
+            // Active
+            // Inactive
+            // OverTime
+            // SportingWithdrawal
+            // NotCompeting
+            // DidNotStart
+            if (is_not_competing)
+                return "NotCompeting";
+            if (is_miss_punch)
+                return "MissingPunch";
+            if (is_did_not_finish)
+                return "DidNotFinish";
+            if (is_did_not_start)
+                return "DidNotStart";
+            if (is_bad_check || is_disq_by_organizer || is_disq)
+                return "Disqualified";
+            if (time)
+                return "OK"; // OK
+            return 0;     // Unknown
+        }
 
-static int mop_start(int runner_start_ms) {
-    int stage_id = getPlugin<EventPlugin>()->currentStageId();
-    QDateTime event_start = getPlugin<EventPlugin>()->stageStartDateTime(stage_id);
-    QDateTime runner_start = event_start.addMSecs(runner_start_ms);
-    return event_start.date().startOfDay().msecsTo(runner_start) / 100;
-}
+        static QString datetime_to_string(const QDateTime &dt)
+        {
+            return quickevent::core::Utils::dateTimeToIsoStringWithUtcOffset(dt);
+        }
 
-static int mop_run_status_code(
-		int time,
-		bool isDisq,
-		bool isDisqByOrganizer,
-		bool isMissPunch,
-		bool isBadCheck,
-		bool isDidNotStart,
-		bool isDidNotFinish,
-		bool isNotCompeting)
-{
-	if (isNotCompeting)
-		return 99; // NP (Not participating)
-	if (isMissPunch)
-		return 3; //MP (Missing punch)
-	if (isDidNotFinish)
-		return 4; // DNF (Did not finish)
-	if (isDidNotStart)
-		return 20; // DNS (Did not start)
-	if (isBadCheck || isDisqByOrganizer || isDisq)
-		return 5; // DQ (Disqualified)
-	if (time)
-		return 1; // OK
-	return 0; // Unknown
-}
+        void OFeedClient::onCompetitorEdited(int competitor_id)
+        {
+            if (competitor_id == 0)
+                return;
 
+            int stage_id = getPlugin<EventPlugin>()->currentStageId();
+            QDateTime stage_start_date_time = getPlugin<EventPlugin>()->stageStartDateTime(stage_id);
+            qf::core::sql::Query q;
+            q.exec("SELECT competitors.registration, "
+                   "competitors.startNumber, "
+                   "competitors.firstName, "
+                   "competitors.lastName, "
+                   "classes.id AS classId, "
+                   "runs.id AS runId, "
+                   "runs.siId, "
+                   "runs.disqualified, "
+                   "runs.disqualifiedByOrganizer, "
+                   "runs.misPunch, "
+                   "runs.badCheck, "
+                   "runs.notStart, "
+                   "runs.notFinish, "
+                   "runs.notCompeting, "
+                   "runs.startTimeMs, "
+                   "runs.finishTimeMs, "
+                   "runs.timeMs "
+                   "FROM runs "
+                   "INNER JOIN competitors ON competitors.id = runs.competitorId "
+                   "LEFT JOIN relays ON relays.id = runs.relayId  "
+                   "INNER JOIN classes ON classes.id = competitors.classId OR classes.id = relays.classId  "
+                   "WHERE competitors.id=" QF_IARG(competitor_id) " AND runs.stageId=" QF_IARG(stage_id),
+                   qf::core::Exception::Throw);
+            if (q.next())
+            {
+                // int run_id = q.value("runId").toInt();
+                int start_bib = q.value(QStringLiteral("startNumber")).toInt();
+                QString first_name = q.value(QStringLiteral("firstName")).toString();
+                QString last_name = q.value(QStringLiteral("lastName")).toString();
+                QString registration = q.value(QStringLiteral("registration")).toString();
+                QString class_id = q.value(QStringLiteral("classId")).toString();
+                int card_number = q.value(QStringLiteral("siId")).toInt();
+                bool is_disq = q.value(QStringLiteral("disqualified")).toBool();
+                bool is_disq_by_organizer = q.value(QStringLiteral("disqualifiedByOrganizer")).toBool();
+                bool is_miss_punch = q.value(QStringLiteral("misPunch")).toBool();
+                bool is_bad_check = q.value(QStringLiteral("badCheck")).toBool();
+                bool is_did_not_start = q.value(QStringLiteral("notStart")).toBool();
+                bool is_did_not_finish = q.value(QStringLiteral("notFinish")).toBool();
+                bool is_not_competing = q.value(QStringLiteral("notCompeting")).toBool();
+                int start_time = q.value(QStringLiteral("startTimeMs")).toInt();
+                int finish_time = q.value(QStringLiteral("finishTimeMs")).toInt();
+                int running_time = q.value(QStringLiteral("timeMs")).toInt();
+                QString status = getIofResultStatus(running_time, is_disq, is_disq_by_organizer, is_miss_punch, is_bad_check, is_did_not_start, is_did_not_finish, is_not_competing);
+                QString origin = "IT";
+                QString note = "Edited from Quickevent";
 
-void OFeedClient::onCompetitorChanged(int competitor_id)
-{
-    if (competitor_id == 0)
-        return;
+                // Use std::stringstream to build the JSON string
+                std::stringstream json_payload;
+                json_payload << "{"
+                             << "\"useExternalId\":true,"
+                             << "\"classExternalId\":\"" << class_id.toStdString() << "\","
+                             << "\"origin\":\"" << origin.toStdString() << "\","
+                             << "\"firstname\":\"" << first_name.toStdString() << "\","
+                             << "\"lastname\":\"" << last_name.toStdString() << "\","
+                             << "\"registration\":\"" << registration.toStdString() << "\","
+                             << "\"bibNumber\":" << start_bib << ","
+                             << "\"card\":" << card_number << ","
+                             << "\"startTime\":\"" << datetime_to_string(stage_start_date_time.addMSecs(start_time)).toStdString() << "\","
+                             << "\"finishTime\":\"" << datetime_to_string(stage_start_date_time.addMSecs(finish_time)).toStdString() << "\","
+                             << "\"time\":" << running_time << ","
+                             << "\"status\":\"" << status.toStdString() << "\","
+                             << "\"note\":\"" << note.toStdString() << "\""
+                             << "}";
 
-    int stage_id = getPlugin<EventPlugin>()->currentStageId();
-    qf::core::sql::Query q;
-    q.exec("SELECT competitors.registration, "
-           "competitors.startNumber, "
-           "competitors.lastName || ' ' || competitors.firstName AS name, "
-           "classes.id AS classId, "
-           "runs.id AS runId, "
-           "runs.siId, "
-           "runs.disqualified, "
-           "runs.disqualifiedByOrganizer, "
-           "runs.misPunch, "
-           "runs.badCheck, "
-           "runs.notStart, "
-           "runs.notFinish, "
-           "runs.notCompeting, "
-           "runs.startTimeMs, "
-           "runs.finishTimeMs, "
-           "runs.timeMs "
-           "FROM runs "
-           "INNER JOIN competitors ON competitors.id = runs.competitorId "
-           "LEFT JOIN relays ON relays.id = runs.relayId  "
-           "INNER JOIN classes ON classes.id = competitors.classId OR classes.id = relays.classId  "
-           "WHERE competitors.id=" QF_IARG(competitor_id) " AND runs.stageId=" QF_IARG(stage_id), qf::core::Exception::Throw);
-    if(q.next()) {
-        int run_id = q.value("runId").toInt();
-        int start_num = q.value("startNumber").toInt();
-        QString name = q.value("name").toString();
-        QString class_id = q.value("classId").toString();
-        int card_num = q.value("siId").toInt();
-        bool isDisq = q.value("disqualified").toBool();
-        bool isDisqByOrganizer = q.value("disqualifiedByOrganizer").toBool();
-        bool isMissPunch = q.value("misPunch").toBool();
-        bool isBadCheck = q.value("badCheck").toBool();
-        bool isDidNotStart = q.value("notStart").toBool();
-        bool isDidNotFinish = q.value("notFinish").toBool();
-        bool isNotCompeting = q.value("notCompeting").toBool();
-        int start_time = q.value("startTimeMs").toInt();
-        int finish_time = q.value("finishTimeMs").toInt();
-        int running_time = q.value("timeMs").toInt();
+                // Get the final JSON string
+                std::string json_str = json_payload.str();
 
-        int status_code = mop_run_status_code(running_time, isDisq, isDisqByOrganizer, isMissPunch, isBadCheck, isDidNotStart, isDidNotFinish, isNotCompeting);
+                // Output the JSON for debugging
+                std::cout << "JSON Payload: " << json_str << std::endl;
+                
+                // Convert std::string to QString
+                QString json_qstr = QString::fromStdString(json_str);
 
-        QVariantMap competitor {
-            {"stat", status_code},
-            {"cls", class_id}
-        };
-        if (start_num != 0)
-            competitor.insert("bib", start_num);
-        if(start_time != 0)
-            competitor.insert("st", mop_start(start_time));
-        if(finish_time > start_time && running_time != 0)
-            competitor.insert("rt", running_time / 100);
-
-
-        QVariantList xml_root{"MOPDiff",
-            QVariantMap {
-                {"xmlns", "http://www.melin.nu/mop"},
-                {"creator", QStringLiteral("QuickEvent %1").arg(QCoreApplication::applicationVersion())},
-                {"createTime", QDateTime::currentDateTimeUtc().toString(Qt::ISODate)}
+                sendCompetitorChange(json_qstr, competitor_id);
             }
-        };
-        QVariantList xml_competitor{"cmp",
-            QVariantMap {
-                {"id", run_id },
-                {"card", card_num },
-            },
-            QVariantList {"base",
-                competitor,
-                name
+        }
+        void OFeedClient::onCompetitorReadOut(int competitor_id)
+        {
+            if (competitor_id == 0)
+                return;
+
+            int stage_id = getPlugin<EventPlugin>()->currentStageId();
+            QDateTime stage_start_date_time = getPlugin<EventPlugin>()->stageStartDateTime(stage_id);
+            qf::core::sql::Query q;
+            q.exec("SELECT runs.disqualified, "
+                   "runs.disqualifiedByOrganizer, "
+                   "runs.misPunch, "
+                   "runs.badCheck, "
+                   "runs.notStart, "
+                   "runs.notFinish, "
+                   "runs.notCompeting, "
+                   "runs.startTimeMs, "
+                   "runs.finishTimeMs, "
+                   "runs.timeMs "
+                   "FROM runs "
+                   "INNER JOIN competitors ON competitors.id = runs.competitorId "
+                   "LEFT JOIN relays ON relays.id = runs.relayId  "
+                   "INNER JOIN classes ON classes.id = competitors.classId OR classes.id = relays.classId  "
+                   "WHERE competitors.id=" QF_IARG(competitor_id) " AND runs.stageId=" QF_IARG(stage_id),
+                   qf::core::Exception::Throw);
+            if (q.next())
+            {
+                bool is_disq = q.value(QStringLiteral("disqualified")).toBool();
+                bool is_disq_by_organizer = q.value(QStringLiteral("disqualifiedByOrganizer")).toBool();
+                bool is_miss_punch = q.value(QStringLiteral("misPunch")).toBool();
+                bool is_bad_check = q.value(QStringLiteral("badCheck")).toBool();
+                bool is_did_not_start = q.value(QStringLiteral("notStart")).toBool();
+                bool is_did_not_finish = q.value(QStringLiteral("notFinish")).toBool();
+                bool is_not_competing = q.value(QStringLiteral("notCompeting")).toBool();
+                int start_time = q.value(QStringLiteral("startTimeMs")).toInt();
+                int finish_time = q.value(QStringLiteral("finishTimeMs")).toInt();
+                int running_time = q.value(QStringLiteral("timeMs")).toInt();
+                QString status = getIofResultStatus(running_time, is_disq, is_disq_by_organizer, is_miss_punch, is_bad_check, is_did_not_start, is_did_not_finish, is_not_competing);
+                QString origin = "IT";
+                QString note = "Quickevent read-out ";
+
+                // Use std::stringstream to build the JSON string
+                std::stringstream json_payload;
+                json_payload << "{"
+                             << "\"useExternalId\":true,"
+                             << "\"origin\":\"" << origin.toStdString() << "\","
+                             << "\"startTime\":\"" << datetime_to_string(stage_start_date_time.addMSecs(start_time)).toStdString() << "\","
+                             << "\"finishTime\":\"" << datetime_to_string(stage_start_date_time.addMSecs(finish_time)).toStdString() << "\","
+                             << "\"time\":" << running_time << ","
+                             << "\"status\":\"" << status.toStdString() << "\","
+                             << "\"note\":\"" << note.toStdString() << "\""
+                             << "}";
+
+                // Get the final JSON string
+                std::string json_str = json_payload.str();
+
+                // Output the JSON for debugging
+                std::cout << "JSON Payload: " << json_str << std::endl;
+                
+                // Convert std::string to QString
+                QString json_qstr = QString::fromStdString(json_str);
+
+                sendCompetitorChange(json_qstr, competitor_id);
             }
-        };
-        append_list(xml_root, xml_competitor);
-        qf::core::utils::HtmlUtils::FromXmlListOptions opts;
-        opts.setDocumentTitle("Competitor change");
-        auto xml_paylaod = qf::core::utils::HtmlUtils::fromXmlList(xml_root, opts);
-        sendCompetitorChange(xml_paylaod);
+        }
     }
 }
-
-QByteArray OFeedClient::zlibCompress(QByteArray data)
-{
-	QByteArray compressedData = qCompress(data);
-	// strip the 4-byte length put on by qCompress
-	// internally qCompress uses zlib
-	compressedData.remove(0, 4);
-	return compressedData;
-}
-}}

--- a/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclient.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclient.h
@@ -52,7 +52,8 @@ private:
     void onExportTimerTimeOut();
     void init();
     void sendFile(QString name, QString request_path, QString file, std::function<void()> on_success = nullptr);
-    void sendCompetitorChange(QString jsonBody, int competitor_id);
+    void sendCompetitorChange(QString json_body, int competitor_id);
+    void sendNewCompetitor(QString json_body);
     void onCompetitorEdited(int competitor_id);
     void onCompetitorReadOut(int competitor_id);
 };

--- a/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclient.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclient.h
@@ -1,0 +1,62 @@
+#ifndef OFEEDCLIENT_H
+#define OFEEDCLIENT_H
+
+#pragma once
+
+#include "../service.h"
+
+class QTimer;
+class QNetworkAccessManager;
+
+namespace Event {
+namespace services {
+
+class OFeedClientSettings : public ServiceSettings
+{
+    using Super = ServiceSettings;
+
+    QF_VARIANTMAP_FIELD2(int, e, setE, xportIntervalSec, 60)
+public:
+    OFeedClientSettings(const QVariantMap &o = QVariantMap()) : Super(o) {}
+};
+
+class OFeedClient : public Service
+{
+    Q_OBJECT
+
+    using Super = Service;
+public:
+    OFeedClient(QObject *parent);
+
+    void run() override;
+    void stop() override;
+    OFeedClientSettings settings() const {return OFeedClientSettings(m_settings);}
+
+    static QString serviceName();
+
+    void exportResultsIofXml3();
+    void exportStartListIofXml3(std::function<void()> on_success = nullptr);
+    void loadSettings() override;
+    void onDbEventNotify(const QString &domain, int connection_id, const QVariant &data);
+    QString hostUrl() const;
+    void setHostUrl(QString eventId);
+    QString eventId() const;
+    void setEventId(QString eventId);
+    QString eventPassword() const;
+    void setEventPassword(QString eventPassword);
+private:
+    QTimer *m_exportTimer = nullptr;
+    QNetworkAccessManager *m_networkManager = nullptr;
+private:
+    qf::qmlwidgets::framework::DialogWidget *createDetailWidget() override;
+    void onExportTimerTimeOut();
+    void init();
+    void sendFile(QString name, QString request_path, QString file, std::function<void()> on_success = nullptr);
+    void sendCompetitorChange(QString xml);
+    void onCompetitorChanged(int competitor_id);
+    QByteArray zlibCompress(QByteArray data);
+};
+
+}}
+
+#endif // OFEEDCLIENT_H

--- a/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclient.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclient.h
@@ -52,9 +52,9 @@ private:
     void onExportTimerTimeOut();
     void init();
     void sendFile(QString name, QString request_path, QString file, std::function<void()> on_success = nullptr);
-    void sendCompetitorChange(QString xml);
-    void onCompetitorChanged(int competitor_id);
-    QByteArray zlibCompress(QByteArray data);
+    void sendCompetitorChange(QString jsonBody, int competitor_id);
+    void onCompetitorEdited(int competitor_id);
+    void onCompetitorReadOut(int competitor_id);
 };
 
 }}

--- a/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclientwidget.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclientwidget.cpp
@@ -1,0 +1,92 @@
+#include "ofeedclientwidget.h"
+#include "ui_ofeedclientwidget.h"
+#include "ofeedclient.h"
+#include <qf/qmlwidgets/framework/mainwindow.h>
+
+#include <qf/qmlwidgets/dialogs/messagebox.h>
+
+#include <qf/core/assert.h>
+
+#include <QFileDialog>
+
+#include <plugins/Event/src/eventplugin.h>
+using qf::qmlwidgets::framework::getPlugin;
+
+namespace Event {
+namespace services {
+
+OFeedClientWidget::OFeedClientWidget(QWidget *parent)
+	: Super(parent)
+    , ui(new Ui::OFeedClientWidget)
+{
+    setPersistentSettingsId("OFeedClientWidget");
+	ui->setupUi(this);
+
+    OFeedClient *svc = service();
+	if(svc) {
+        OFeedClientSettings ss = svc->settings();
+		ui->edExportInterval->setValue(ss.exportIntervalSec());
+        ui->edHostUrl->setText(svc->hostUrl());
+        ui->edEventId->setText(svc->eventId());
+        ui->edEventPassword->setText(svc->eventPassword());
+	}
+
+    connect(ui->btExportResultsXml30, &QPushButton::clicked, this, &OFeedClientWidget::onBtExportResultsXml30Clicked);
+    connect(ui->btExportStartListXml30, &QPushButton::clicked, this, &OFeedClientWidget::onBtExportStartListXml30Clicked);
+}
+
+OFeedClientWidget::~OFeedClientWidget()
+{
+	delete ui;
+}
+
+bool OFeedClientWidget::acceptDialogDone(int result)
+{
+	if(result == QDialog::Accepted) {
+		if(!saveSettings()) {
+			return false;
+		}
+	}
+	return true;
+}
+
+OFeedClient *OFeedClientWidget::service()
+{
+    OFeedClient *svc = qobject_cast<OFeedClient*>(Service::serviceByName(OFeedClient::serviceName()));
+    QF_ASSERT(svc, OFeedClient::serviceName() + " doesn't exist", return nullptr);
+	return svc;
+}
+
+bool OFeedClientWidget::saveSettings()
+{
+    OFeedClient *svc = service();
+	if(svc) {
+        OFeedClientSettings ss = svc->settings();
+		ss.setExportIntervalSec(ui->edExportInterval->value());
+        svc->setHostUrl(ui->edHostUrl->text().trimmed());
+        svc->setEventId(ui->edEventId->text().trimmed());
+        svc->setEventPassword(ui->edEventPassword->text().trimmed());
+		svc->setSettings(ss);
+	}
+	return true;
+}
+
+void OFeedClientWidget::onBtExportResultsXml30Clicked()
+{
+    OFeedClient *svc = service();
+	if(svc) {
+		saveSettings();
+		svc->exportResultsIofXml3();
+	}
+}
+
+void OFeedClientWidget::onBtExportStartListXml30Clicked()
+{
+    OFeedClient *svc = service();
+	if(svc) {
+		saveSettings();
+		svc->exportStartListIofXml3();
+	}
+}
+}}
+

--- a/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclientwidget.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclientwidget.cpp
@@ -6,6 +6,7 @@
 #include <qf/qmlwidgets/dialogs/messagebox.h>
 
 #include <qf/core/assert.h>
+#include <qf/core/log.h>
 
 #include <QFileDialog>
 
@@ -76,6 +77,7 @@ void OFeedClientWidget::onBtExportResultsXml30Clicked()
     OFeedClient *svc = service();
 	if(svc) {
 		saveSettings();
+		qfInfo() << "OFeed [results - manual upload]";
 		svc->exportResultsIofXml3();
 	}
 }
@@ -85,6 +87,7 @@ void OFeedClientWidget::onBtExportStartListXml30Clicked()
     OFeedClient *svc = service();
 	if(svc) {
 		saveSettings();
+		qfInfo() << "OFeed [startlist - manual upload]";
 		svc->exportStartListIofXml3();
 	}
 }

--- a/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclientwidget.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclientwidget.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <qf/qmlwidgets/framework/dialogwidget.h>
+
+namespace Event {
+namespace services {
+
+namespace Ui {
+class OFeedClientWidget;
+}
+
+class OFeedClient;
+
+class OFeedClientWidget : public qf::qmlwidgets::framework::DialogWidget
+{
+	Q_OBJECT
+
+	using Super = qf::qmlwidgets::framework::DialogWidget;
+public:
+    explicit OFeedClientWidget(QWidget *parent = nullptr);
+    ~OFeedClientWidget();
+private:
+	void onBtExportResultsXml30Clicked();
+	void onBtExportStartListXml30Clicked();
+    OFeedClient* service();
+	bool saveSettings();
+private:
+    Ui::OFeedClientWidget *ui;
+	bool acceptDialogDone(int result);
+};
+
+}}

--- a/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclientwidget.ui
+++ b/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclientwidget.ui
@@ -7,103 +7,130 @@
     <x>0</x>
     <y>0</y>
     <width>298</width>
-    <height>350</height>
+    <height>555</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Real-Time Orienteering Data with OFeed platform</string>
+   <string>Synchronize data with the OFeed platform</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QFormLayout" name="formLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="export_interval_label">
-       <property name="text">
-        <string>Export interval</string>
+    <widget class="QGroupBox" name="groupCredentials">
+     <property name="title">
+      <string>Service credentials</string>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="layoutWidget">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>20</y>
+        <width>281</width>
+        <height>111</height>
+       </rect>
+      </property>
+      <layout class="QFormLayout" name="formLayout">
+       <property name="horizontalSpacing">
+        <number>6</number>
        </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QSpinBox" name="edExportInterval">
-       <property name="alignment">
-        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+       <property name="verticalSpacing">
+        <number>6</number>
        </property>
-       <property name="suffix">
-        <string> sec</string>
-       </property>
-       <property name="minimum">
-        <number>10</number>
-       </property>
-       <property name="maximum">
-        <number>600</number>
-       </property>
-       <property name="singleStep">
-        <number>10</number>
-       </property>
-       <property name="value">
-        <number>60</number>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="url_label">
-       <property name="text">
-        <string>Url</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="edHostUrl">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;https://api.orienteeringfeed.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="event_id_label">
-       <property name="text">
-        <string>Event id</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QLineEdit" name="edEventId">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;cm2kwm3dz0008s43pa1i7rngb&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="password_label">
-       <property name="text">
-        <string>Password</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QLineEdit" name="edEventPassword">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;gps-stone-map99%&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+       <item row="0" column="0">
+        <widget class="QLabel" name="export_interval_label">
+         <property name="text">
+          <string>Export interval</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QSpinBox" name="edExportInterval">
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+         <property name="suffix">
+          <string> sec</string>
+         </property>
+         <property name="minimum">
+          <number>10</number>
+         </property>
+         <property name="maximum">
+          <number>600</number>
+         </property>
+         <property name="singleStep">
+          <number>10</number>
+         </property>
+         <property name="value">
+          <number>60</number>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="url_label">
+         <property name="text">
+          <string>Url</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLineEdit" name="edHostUrl">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;https://api.orienteeringfeed.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="event_id_label">
+         <property name="text">
+          <string>Event id</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLineEdit" name="edEventId">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;cm2kwm3dz0008s43pa1i7rngb&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="password_label">
+         <property name="text">
+          <string>Password</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QLineEdit" name="edEventPassword">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;gps-stone-map99%&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupUploadData">
      <property name="title">
-      <string/>
+      <string>Upload data</string>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QTableView" name="changes_table_view"/>
-      </item>
-      <item>
-       <widget class="QLabel" name="service_description">
+       <widget class="QLabel" name="upload_description">
         <property name="text">
-         <string>Start lists and Results are exported at given interval.
-Both Results and Start list can be exported manually using the buttons bellow. In addition, if the service is running, individual competitor data is send after readout and after saving competitor dialog.
-In case of unexpected errors, contact support@orienteerfeed.com</string>
+         <string>Start lists and results are automatically exported at specified intervals, with changes such as edited competitor data or new competitors being synced in real-time. Both the results and start lists can also be exported manually using the buttons below. Additionally, when the service is active, individual competitor data is sent after readout and upon saving the competitor dialog.
+
+If you encounter any unexpected errors, please contact us at support@orienteerfeed.com or create an issue on our GitHub page.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -144,11 +171,45 @@ In case of unexpected errors, contact support@orienteerfeed.com</string>
      </layout>
     </widget>
    </item>
+   <item>
+    <widget class="QGroupBox" name="groupGetData">
+     <property name="title">
+      <string>Get changes from the start</string>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+     <widget class="QLabel" name="get_description">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>20</y>
+        <width>241</width>
+        <height>51</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Sync changes from the start to the Quickevent (start status, new card numbers and notes).</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QTableWidget" name="tableChanges">
+      <property name="geometry">
+       <rect>
+        <x>-5</x>
+        <y>81</y>
+        <width>291</width>
+        <height>181</height>
+       </rect>
+      </property>
+     </widget>
+    </widget>
+   </item>
   </layout>
  </widget>
  <tabstops>
-  <tabstop>edExportInterval</tabstop>
-  <tabstop>edHostUrl</tabstop>
   <tabstop>btExportStartListXml30</tabstop>
   <tabstop>btExportResultsXml30</tabstop>
  </tabstops>

--- a/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclientwidget.ui
+++ b/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclientwidget.ui
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Event::services::OFeedClientWidget</class>
+ <widget class="QWidget" name="Event::services::OFeedClientWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>298</width>
+    <height>350</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Real-Time Orienteering Data with OFeed platform</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="export_interval_label">
+       <property name="text">
+        <string>Export interval</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QSpinBox" name="edExportInterval">
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+       </property>
+       <property name="suffix">
+        <string> sec</string>
+       </property>
+       <property name="minimum">
+        <number>10</number>
+       </property>
+       <property name="maximum">
+        <number>600</number>
+       </property>
+       <property name="singleStep">
+        <number>10</number>
+       </property>
+       <property name="value">
+        <number>60</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="url_label">
+       <property name="text">
+        <string>Url</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="edHostUrl">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;https://api.orienteeringfeed.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="event_id_label">
+       <property name="text">
+        <string>Event id</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="edEventId">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;cm2kwm3dz0008s43pa1i7rngb&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="password_label">
+       <property name="text">
+        <string>Password</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLineEdit" name="edEventPassword">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;gps-stone-map99%&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string/>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Start lists and Results are exported at given interval.
+Both Results and Start list can be exported manually using the buttons bellow. In addition, if the service is running, individual competitor data is send after readout and after saving competitor dialog.
+In case of unexpected errors, contact support@orienteerfeed.com</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btExportStartListXml30">
+          <property name="text">
+           <string>Export start list</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btExportResultsXml30">
+          <property name="text">
+           <string>Export results</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>edExportInterval</tabstop>
+  <tabstop>edHostUrl</tabstop>
+  <tabstop>btExportStartListXml30</tabstop>
+  <tabstop>btExportResultsXml30</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclientwidget.ui
+++ b/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclientwidget.ui
@@ -96,7 +96,10 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QLabel" name="label">
+       <widget class="QTableView" name="changes_table_view"/>
+      </item>
+      <item>
+       <widget class="QLabel" name="service_description">
         <property name="text">
          <string>Start lists and Results are exported at given interval.
 Both Results and Start list can be exported manually using the buttons bellow. In addition, if the service is running, individual competitor data is send after readout and after saving competitor dialog.


### PR DESCRIPTION
The service features:
- manually upload data - start list, results
- regular results data upload (according to the set interval)
- send changes - edited competitor, new competitor, read out data

TODO:
- [ ] Process changes that come from start/OChecklist app (origin=START) - changed status, card number or note
- [ ] Add a more sophisticated way to distinguish between new and edited competitors (compares competitor id and actual sequence value at this moment) because both actions invokes the same db event.