### PR TITLE
Add missing qm translation files generation for libqfcore

### DIFF
--- a/libqf/libqfcore/CMakeLists.txt
+++ b/libqf/libqfcore/CMakeLists.txt
@@ -54,6 +54,7 @@ qt6_add_lupdate(libqfcore TS_FILES
 	libqfcore-uk_UA.ts
 	)
 
+target_sources(libqfcore PRIVATE ${QM_FILES})
 target_link_libraries(libqfcore PUBLIC libnecrolog Qt::Core Qt::Sql PRIVATE Qt::Gui Qt::Qml Qt::Xml libnecrolog)
 target_include_directories(libqfcore PUBLIC include)
 target_compile_definitions(libqfcore PRIVATE QFCORE_BUILD_DLL)


### PR DESCRIPTION
.qm files for libqfcore are now generated on build.