### PR TITLE
QE3 - Some relay fixes and improvements

### DIFF
--- a/.github/actions/cmake/action.yml
+++ b/.github/actions/cmake/action.yml
@@ -68,7 +68,6 @@ runs:
         -DQF_BUILD_QML_PLUGINS=ON \
         -DBUILD_TESTING=OFF \
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-        -DCMAKE_BUILD_TYPE=Debug \
         -DUSE_QT6=${{ inputs.use_qt6 }} \
         -DCOMMIT_SHA=${{ env.COMMIT_SHA }} \
         ${{ env.cmake_extra_args }} \

--- a/libquickevent/libquickeventgui/libquickeventgui-cs_CZ.ts
+++ b/libquickevent/libquickeventgui/libquickeventgui-cs_CZ.ts
@@ -9,226 +9,236 @@
         <translation>Nastavení tisku</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="51"/>
+        <location filename="src/reportoptionsdialog.ui" line="60"/>
         <source>Stages count</source>
         <translation>Počet etap</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="57"/>
+        <location filename="src/reportoptionsdialog.ui" line="66"/>
         <source>Number of stages</source>
         <translation>Počet etap</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="32"/>
+        <location filename="src/reportoptionsdialog.ui" line="247"/>
         <source>Legs count</source>
         <translation>Počet úseků</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="38"/>
+        <location filename="src/reportoptionsdialog.ui" line="253"/>
         <source>Number of legs</source>
         <translation>Počet úseků</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="70"/>
+        <location filename="src/reportoptionsdialog.ui" line="266"/>
         <source>Class filter</source>
         <translation>Filtr kategorií</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="114"/>
+        <location filename="src/reportoptionsdialog.ui" line="310"/>
         <source>Posix regular expression</source>
         <translation>POSIX regulární výraz</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="117"/>
+        <location filename="src/reportoptionsdialog.ui" line="313"/>
         <source>RegExp</source>
         <translation>Regulární výraz</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="101"/>
+        <location filename="src/reportoptionsdialog.ui" line="297"/>
         <source>An question mark (?) in pattern stands for (matches) any single character; a asterisk (*) matches any sequence of zero or more characters.</source>
         <translation>Otazník (?) zastupuje jeden libovolný znak, hvězdička (*) zastupuje posloupnost 0–n libovolných znaků.</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="104"/>
+        <location filename="src/reportoptionsdialog.ui" line="300"/>
         <source>Wild card</source>
         <translation>Zástupné znaky</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="94"/>
+        <location filename="src/reportoptionsdialog.ui" line="290"/>
         <source>Doesn&apos;t match</source>
         <translation>Nevyhovuje filtru</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="124"/>
+        <location filename="src/reportoptionsdialog.ui" line="320"/>
         <source>Coma delimited list of class names</source>
         <translation>Seznam kategorií oddělených čárkou</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="127"/>
-        <location filename="src/reportoptionsdialog.ui" line="470"/>
+        <location filename="src/reportoptionsdialog.ui" line="323"/>
+        <location filename="src/reportoptionsdialog.ui" line="416"/>
         <source>Class names</source>
         <translation>Jmén kategorií</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="226"/>
+        <location filename="src/reportoptionsdialog.ui" line="487"/>
         <source>Result options</source>
         <translation>Možnosti pro výsledky</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="232"/>
+        <location filename="src/reportoptionsdialog.ui" line="493"/>
         <source>Number of places in each class</source>
         <translation>Maximální počet míst v každé kategorii</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="255"/>
+        <location filename="src/reportoptionsdialog.ui" line="516"/>
         <source>Exclude DISQ</source>
         <translation>Nezahrnovat DISK</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="140"/>
+        <location filename="src/reportoptionsdialog.ui" line="446"/>
         <source>Starters options</source>
         <translation>Možnosti pro startéry</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="158"/>
+        <location filename="src/reportoptionsdialog.ui" line="464"/>
         <source>Space after line</source>
         <translation>Mezera po řádku</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="168"/>
+        <location filename="src/reportoptionsdialog.ui" line="474"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="181"/>
+        <location filename="src/reportoptionsdialog.ui" line="336"/>
         <source>Start options</source>
         <translation>Možnosti pro startovní listiny</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="199"/>
+        <location filename="src/reportoptionsdialog.ui" line="354"/>
         <source>Print vacants</source>
         <translation>Tisknout vakanty</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="206"/>
+        <location filename="src/reportoptionsdialog.ui" line="361"/>
         <source>Print start numbers</source>
         <translation>Tisknout startovní čísla</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="442"/>
+        <location filename="src/reportoptionsdialog.ui" line="41"/>
         <source>Reset</source>
         <translation>Resetovat</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="461"/>
+        <location filename="src/reportoptionsdialog.ui" line="407"/>
         <source>Start list is sorted first by</source>
         <translation>Startovní listina je tříděna jako první dle</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="467"/>
+        <location filename="src/reportoptionsdialog.ui" line="413"/>
         <source>(class name, start time, runner name)</source>
         <translation>(jméno kategorie, startovní čas, jméno závodníka)</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="477"/>
+        <location filename="src/reportoptionsdialog.ui" line="423"/>
         <source>(start time, class name, runner name)</source>
         <translation>(startovní čas, jméno kategorie, jméno závodníka)</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="480"/>
+        <location filename="src/reportoptionsdialog.ui" line="426"/>
         <source>Start times</source>
         <translation>Startovních časů</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="487"/>
+        <location filename="src/reportoptionsdialog.ui" line="433"/>
         <source>(runner name, class name, start time)</source>
         <translation>(jméno závodníka, jméno kategorie, startovní čas)</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="490"/>
+        <location filename="src/reportoptionsdialog.ui" line="436"/>
         <source>Runner names</source>
         <translation>Jmen běžců</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="513"/>
+        <location filename="src/reportoptionsdialog.ui" line="381"/>
         <source>Start time format</source>
         <translation>Formát startovního času</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="519"/>
+        <location filename="src/reportoptionsdialog.ui" line="387"/>
         <source>start at 0 (mmm.ss)  </source>
         <translation>čas od 0 (mmm:ss)  </translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="529"/>
+        <location filename="src/reportoptionsdialog.ui" line="397"/>
         <source>daytime (hh:mm:ss)</source>
         <translation>denní čas (hh:mm:ss)</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="265"/>
+        <location filename="src/reportoptionsdialog.ui" line="79"/>
         <source>Page layout</source>
         <translation>Rozvržení stránky</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="213"/>
+        <location filename="src/reportoptionsdialog.ui" line="368"/>
         <source>Use only class from selected start</source>
         <translation>Pooužít pouze kategorie z vybraného startu</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="283"/>
+        <location filename="src/reportoptionsdialog.ui" line="97"/>
         <source>Horizontal margin</source>
         <translation>Horizontální okraje</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="290"/>
-        <location filename="src/reportoptionsdialog.ui" line="336"/>
-        <location filename="src/reportoptionsdialog.ui" line="359"/>
-        <location filename="src/reportoptionsdialog.ui" line="385"/>
+        <location filename="src/reportoptionsdialog.ui" line="104"/>
+        <location filename="src/reportoptionsdialog.ui" line="150"/>
+        <location filename="src/reportoptionsdialog.ui" line="173"/>
+        <location filename="src/reportoptionsdialog.ui" line="199"/>
         <source> mm</source>
         <translation> mm</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="322"/>
+        <location filename="src/reportoptionsdialog.ui" line="136"/>
         <source>Column count</source>
         <translation>Počet sloupců</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="329"/>
+        <location filename="src/reportoptionsdialog.ui" line="143"/>
         <source>Vertical margin</source>
         <translation>Vertikální okraje</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="352"/>
+        <location filename="src/reportoptionsdialog.ui" line="166"/>
         <source>Page width</source>
         <translation>Šířka stránky</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="378"/>
+        <location filename="src/reportoptionsdialog.ui" line="192"/>
         <source>Page height</source>
         <translation>Výška stránky</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="404"/>
+        <location filename="src/reportoptionsdialog.ui" line="218"/>
         <source>Break type</source>
         <translation>Typ zalomení</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="412"/>
+        <location filename="src/reportoptionsdialog.ui" line="226"/>
         <source>None</source>
         <translation>Žádné</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="417"/>
+        <location filename="src/reportoptionsdialog.ui" line="231"/>
         <source>Column</source>
         <translation>Sloupec</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="422"/>
+        <location filename="src/reportoptionsdialog.ui" line="236"/>
         <source>Page</source>
         <translation>Stránka</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="435"/>
+        <location filename="src/reportoptionsdialog.ui" line="539"/>
+        <source>Relay options</source>
+        <translation>Možnosti pro štafety</translation>
+    </message>
+    <message>
+        <location filename="src/reportoptionsdialog.ui" line="545"/>
+        <source>Show legs details</source>
+        <translation>Zobrazit detaily úseků (závodníky)</translation>
+    </message>
+    <message>
+        <location filename="src/reportoptionsdialog.ui" line="34"/>
         <source>Save as default</source>
         <translation>Uložit jako výchozí</translation>
     </message>

--- a/libquickevent/libquickeventgui/libquickeventgui-fr_FR.ts
+++ b/libquickevent/libquickeventgui/libquickeventgui-fr_FR.ts
@@ -9,229 +9,239 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="32"/>
+        <location filename="src/reportoptionsdialog.ui" line="247"/>
         <source>Legs count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="38"/>
+        <location filename="src/reportoptionsdialog.ui" line="253"/>
         <source>Number of legs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="51"/>
+        <location filename="src/reportoptionsdialog.ui" line="60"/>
         <source>Stages count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="57"/>
+        <location filename="src/reportoptionsdialog.ui" line="66"/>
         <source>Number of stages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="70"/>
+        <location filename="src/reportoptionsdialog.ui" line="266"/>
         <source>Class filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="94"/>
+        <location filename="src/reportoptionsdialog.ui" line="290"/>
         <source>Doesn&apos;t match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="101"/>
+        <location filename="src/reportoptionsdialog.ui" line="297"/>
         <source>An question mark (?) in pattern stands for (matches) any single character; a asterisk (*) matches any sequence of zero or more characters.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="104"/>
+        <location filename="src/reportoptionsdialog.ui" line="300"/>
         <source>Wild card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="114"/>
+        <location filename="src/reportoptionsdialog.ui" line="310"/>
         <source>Posix regular expression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="117"/>
+        <location filename="src/reportoptionsdialog.ui" line="313"/>
         <source>RegExp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="124"/>
+        <location filename="src/reportoptionsdialog.ui" line="320"/>
         <source>Coma delimited list of class names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="127"/>
-        <location filename="src/reportoptionsdialog.ui" line="470"/>
+        <location filename="src/reportoptionsdialog.ui" line="323"/>
+        <location filename="src/reportoptionsdialog.ui" line="416"/>
         <source>Class names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="140"/>
+        <location filename="src/reportoptionsdialog.ui" line="446"/>
         <source>Starters options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="158"/>
+        <location filename="src/reportoptionsdialog.ui" line="464"/>
         <source>Space after line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="168"/>
+        <location filename="src/reportoptionsdialog.ui" line="474"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="181"/>
+        <location filename="src/reportoptionsdialog.ui" line="539"/>
+        <source>Relay options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="src/reportoptionsdialog.ui" line="545"/>
+        <source>Show legs details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="src/reportoptionsdialog.ui" line="336"/>
         <source>Start options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="199"/>
+        <location filename="src/reportoptionsdialog.ui" line="354"/>
         <source>Print vacants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="206"/>
+        <location filename="src/reportoptionsdialog.ui" line="361"/>
         <source>Print start numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="213"/>
+        <location filename="src/reportoptionsdialog.ui" line="368"/>
         <source>Use only class from selected start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="226"/>
+        <location filename="src/reportoptionsdialog.ui" line="487"/>
         <source>Result options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="232"/>
+        <location filename="src/reportoptionsdialog.ui" line="493"/>
         <source>Number of places in each class</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="255"/>
+        <location filename="src/reportoptionsdialog.ui" line="516"/>
         <source>Exclude DISQ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="265"/>
+        <location filename="src/reportoptionsdialog.ui" line="79"/>
         <source>Page layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="283"/>
+        <location filename="src/reportoptionsdialog.ui" line="97"/>
         <source>Horizontal margin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="290"/>
-        <location filename="src/reportoptionsdialog.ui" line="336"/>
-        <location filename="src/reportoptionsdialog.ui" line="359"/>
-        <location filename="src/reportoptionsdialog.ui" line="385"/>
+        <location filename="src/reportoptionsdialog.ui" line="104"/>
+        <location filename="src/reportoptionsdialog.ui" line="150"/>
+        <location filename="src/reportoptionsdialog.ui" line="173"/>
+        <location filename="src/reportoptionsdialog.ui" line="199"/>
         <source> mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="322"/>
+        <location filename="src/reportoptionsdialog.ui" line="136"/>
         <source>Column count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="329"/>
+        <location filename="src/reportoptionsdialog.ui" line="143"/>
         <source>Vertical margin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="352"/>
+        <location filename="src/reportoptionsdialog.ui" line="166"/>
         <source>Page width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="378"/>
+        <location filename="src/reportoptionsdialog.ui" line="192"/>
         <source>Page height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="404"/>
+        <location filename="src/reportoptionsdialog.ui" line="218"/>
         <source>Break type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="412"/>
+        <location filename="src/reportoptionsdialog.ui" line="226"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="417"/>
+        <location filename="src/reportoptionsdialog.ui" line="231"/>
         <source>Column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="422"/>
+        <location filename="src/reportoptionsdialog.ui" line="236"/>
         <source>Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="435"/>
+        <location filename="src/reportoptionsdialog.ui" line="34"/>
         <source>Save as default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="442"/>
+        <location filename="src/reportoptionsdialog.ui" line="41"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="461"/>
+        <location filename="src/reportoptionsdialog.ui" line="407"/>
         <source>Start list is sorted first by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="467"/>
+        <location filename="src/reportoptionsdialog.ui" line="413"/>
         <source>(class name, start time, runner name)</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(class name, start time,  runner name)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="477"/>
+        <location filename="src/reportoptionsdialog.ui" line="423"/>
         <source>(start time, class name, runner name)</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(start time, class name, runner name)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="480"/>
+        <location filename="src/reportoptionsdialog.ui" line="426"/>
         <source>Start times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="487"/>
+        <location filename="src/reportoptionsdialog.ui" line="433"/>
         <source>(runner name, class name, start time)</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(runner name, class name, start time)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="490"/>
+        <location filename="src/reportoptionsdialog.ui" line="436"/>
         <source>Runner names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="513"/>
+        <location filename="src/reportoptionsdialog.ui" line="381"/>
         <source>Start time format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="519"/>
+        <location filename="src/reportoptionsdialog.ui" line="387"/>
         <source>start at 0 (mmm.ss)  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="529"/>
+        <location filename="src/reportoptionsdialog.ui" line="397"/>
         <source>daytime (hh:mm:ss)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/libquickevent/libquickeventgui/libquickeventgui-nb_NO.ts
+++ b/libquickevent/libquickeventgui/libquickeventgui-nb_NO.ts
@@ -9,229 +9,239 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="32"/>
+        <location filename="src/reportoptionsdialog.ui" line="247"/>
         <source>Legs count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="38"/>
+        <location filename="src/reportoptionsdialog.ui" line="253"/>
         <source>Number of legs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="51"/>
+        <location filename="src/reportoptionsdialog.ui" line="60"/>
         <source>Stages count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="57"/>
+        <location filename="src/reportoptionsdialog.ui" line="66"/>
         <source>Number of stages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="70"/>
+        <location filename="src/reportoptionsdialog.ui" line="266"/>
         <source>Class filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="94"/>
+        <location filename="src/reportoptionsdialog.ui" line="290"/>
         <source>Doesn&apos;t match</source>
         <translation>Samsvarer ikke</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="101"/>
+        <location filename="src/reportoptionsdialog.ui" line="297"/>
         <source>An question mark (?) in pattern stands for (matches) any single character; a asterisk (*) matches any sequence of zero or more characters.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="104"/>
+        <location filename="src/reportoptionsdialog.ui" line="300"/>
         <source>Wild card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="114"/>
+        <location filename="src/reportoptionsdialog.ui" line="310"/>
         <source>Posix regular expression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="117"/>
+        <location filename="src/reportoptionsdialog.ui" line="313"/>
         <source>RegExp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="124"/>
+        <location filename="src/reportoptionsdialog.ui" line="320"/>
         <source>Coma delimited list of class names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="127"/>
-        <location filename="src/reportoptionsdialog.ui" line="470"/>
+        <location filename="src/reportoptionsdialog.ui" line="323"/>
+        <location filename="src/reportoptionsdialog.ui" line="416"/>
         <source>Class names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="140"/>
+        <location filename="src/reportoptionsdialog.ui" line="446"/>
         <source>Starters options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="158"/>
+        <location filename="src/reportoptionsdialog.ui" line="464"/>
         <source>Space after line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="168"/>
+        <location filename="src/reportoptionsdialog.ui" line="474"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="181"/>
+        <location filename="src/reportoptionsdialog.ui" line="539"/>
+        <source>Relay options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="src/reportoptionsdialog.ui" line="545"/>
+        <source>Show legs details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="src/reportoptionsdialog.ui" line="336"/>
         <source>Start options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="199"/>
+        <location filename="src/reportoptionsdialog.ui" line="354"/>
         <source>Print vacants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="206"/>
+        <location filename="src/reportoptionsdialog.ui" line="361"/>
         <source>Print start numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="213"/>
+        <location filename="src/reportoptionsdialog.ui" line="368"/>
         <source>Use only class from selected start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="226"/>
+        <location filename="src/reportoptionsdialog.ui" line="487"/>
         <source>Result options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="232"/>
+        <location filename="src/reportoptionsdialog.ui" line="493"/>
         <source>Number of places in each class</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="255"/>
+        <location filename="src/reportoptionsdialog.ui" line="516"/>
         <source>Exclude DISQ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="265"/>
+        <location filename="src/reportoptionsdialog.ui" line="79"/>
         <source>Page layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="283"/>
+        <location filename="src/reportoptionsdialog.ui" line="97"/>
         <source>Horizontal margin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="290"/>
-        <location filename="src/reportoptionsdialog.ui" line="336"/>
-        <location filename="src/reportoptionsdialog.ui" line="359"/>
-        <location filename="src/reportoptionsdialog.ui" line="385"/>
+        <location filename="src/reportoptionsdialog.ui" line="104"/>
+        <location filename="src/reportoptionsdialog.ui" line="150"/>
+        <location filename="src/reportoptionsdialog.ui" line="173"/>
+        <location filename="src/reportoptionsdialog.ui" line="199"/>
         <source> mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="322"/>
+        <location filename="src/reportoptionsdialog.ui" line="136"/>
         <source>Column count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="329"/>
+        <location filename="src/reportoptionsdialog.ui" line="143"/>
         <source>Vertical margin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="352"/>
+        <location filename="src/reportoptionsdialog.ui" line="166"/>
         <source>Page width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="378"/>
+        <location filename="src/reportoptionsdialog.ui" line="192"/>
         <source>Page height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="404"/>
+        <location filename="src/reportoptionsdialog.ui" line="218"/>
         <source>Break type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="412"/>
+        <location filename="src/reportoptionsdialog.ui" line="226"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="417"/>
+        <location filename="src/reportoptionsdialog.ui" line="231"/>
         <source>Column</source>
         <translation>Kolonne</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="422"/>
+        <location filename="src/reportoptionsdialog.ui" line="236"/>
         <source>Page</source>
         <translation>Side</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="435"/>
+        <location filename="src/reportoptionsdialog.ui" line="34"/>
         <source>Save as default</source>
         <translation>Lagre som forvalg</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="442"/>
+        <location filename="src/reportoptionsdialog.ui" line="41"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="461"/>
+        <location filename="src/reportoptionsdialog.ui" line="407"/>
         <source>Start list is sorted first by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="467"/>
+        <location filename="src/reportoptionsdialog.ui" line="413"/>
         <source>(class name, start time, runner name)</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(class name, start time,  runner name)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="477"/>
+        <location filename="src/reportoptionsdialog.ui" line="423"/>
         <source>(start time, class name, runner name)</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(start time, class name, runner name)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="480"/>
+        <location filename="src/reportoptionsdialog.ui" line="426"/>
         <source>Start times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="487"/>
+        <location filename="src/reportoptionsdialog.ui" line="433"/>
         <source>(runner name, class name, start time)</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(runner name, class name, start time)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="490"/>
+        <location filename="src/reportoptionsdialog.ui" line="436"/>
         <source>Runner names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="513"/>
+        <location filename="src/reportoptionsdialog.ui" line="381"/>
         <source>Start time format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="519"/>
+        <location filename="src/reportoptionsdialog.ui" line="387"/>
         <source>start at 0 (mmm.ss)  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="529"/>
+        <location filename="src/reportoptionsdialog.ui" line="397"/>
         <source>daytime (hh:mm:ss)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/libquickevent/libquickeventgui/libquickeventgui-nl_BE.ts
+++ b/libquickevent/libquickeventgui/libquickeventgui-nl_BE.ts
@@ -9,229 +9,239 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="32"/>
+        <location filename="src/reportoptionsdialog.ui" line="247"/>
         <source>Legs count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="38"/>
+        <location filename="src/reportoptionsdialog.ui" line="253"/>
         <source>Number of legs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="51"/>
+        <location filename="src/reportoptionsdialog.ui" line="60"/>
         <source>Stages count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="57"/>
+        <location filename="src/reportoptionsdialog.ui" line="66"/>
         <source>Number of stages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="70"/>
+        <location filename="src/reportoptionsdialog.ui" line="266"/>
         <source>Class filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="94"/>
+        <location filename="src/reportoptionsdialog.ui" line="290"/>
         <source>Doesn&apos;t match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="101"/>
+        <location filename="src/reportoptionsdialog.ui" line="297"/>
         <source>An question mark (?) in pattern stands for (matches) any single character; a asterisk (*) matches any sequence of zero or more characters.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="104"/>
+        <location filename="src/reportoptionsdialog.ui" line="300"/>
         <source>Wild card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="114"/>
+        <location filename="src/reportoptionsdialog.ui" line="310"/>
         <source>Posix regular expression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="117"/>
+        <location filename="src/reportoptionsdialog.ui" line="313"/>
         <source>RegExp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="124"/>
+        <location filename="src/reportoptionsdialog.ui" line="320"/>
         <source>Coma delimited list of class names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="127"/>
-        <location filename="src/reportoptionsdialog.ui" line="470"/>
+        <location filename="src/reportoptionsdialog.ui" line="323"/>
+        <location filename="src/reportoptionsdialog.ui" line="416"/>
         <source>Class names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="140"/>
+        <location filename="src/reportoptionsdialog.ui" line="446"/>
         <source>Starters options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="158"/>
+        <location filename="src/reportoptionsdialog.ui" line="464"/>
         <source>Space after line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="168"/>
+        <location filename="src/reportoptionsdialog.ui" line="474"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="181"/>
+        <location filename="src/reportoptionsdialog.ui" line="539"/>
+        <source>Relay options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="src/reportoptionsdialog.ui" line="545"/>
+        <source>Show legs details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="src/reportoptionsdialog.ui" line="336"/>
         <source>Start options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="199"/>
+        <location filename="src/reportoptionsdialog.ui" line="354"/>
         <source>Print vacants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="206"/>
+        <location filename="src/reportoptionsdialog.ui" line="361"/>
         <source>Print start numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="213"/>
+        <location filename="src/reportoptionsdialog.ui" line="368"/>
         <source>Use only class from selected start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="226"/>
+        <location filename="src/reportoptionsdialog.ui" line="487"/>
         <source>Result options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="232"/>
+        <location filename="src/reportoptionsdialog.ui" line="493"/>
         <source>Number of places in each class</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="255"/>
+        <location filename="src/reportoptionsdialog.ui" line="516"/>
         <source>Exclude DISQ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="265"/>
+        <location filename="src/reportoptionsdialog.ui" line="79"/>
         <source>Page layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="283"/>
+        <location filename="src/reportoptionsdialog.ui" line="97"/>
         <source>Horizontal margin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="290"/>
-        <location filename="src/reportoptionsdialog.ui" line="336"/>
-        <location filename="src/reportoptionsdialog.ui" line="359"/>
-        <location filename="src/reportoptionsdialog.ui" line="385"/>
+        <location filename="src/reportoptionsdialog.ui" line="104"/>
+        <location filename="src/reportoptionsdialog.ui" line="150"/>
+        <location filename="src/reportoptionsdialog.ui" line="173"/>
+        <location filename="src/reportoptionsdialog.ui" line="199"/>
         <source> mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="322"/>
+        <location filename="src/reportoptionsdialog.ui" line="136"/>
         <source>Column count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="329"/>
+        <location filename="src/reportoptionsdialog.ui" line="143"/>
         <source>Vertical margin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="352"/>
+        <location filename="src/reportoptionsdialog.ui" line="166"/>
         <source>Page width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="378"/>
+        <location filename="src/reportoptionsdialog.ui" line="192"/>
         <source>Page height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="404"/>
+        <location filename="src/reportoptionsdialog.ui" line="218"/>
         <source>Break type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="412"/>
+        <location filename="src/reportoptionsdialog.ui" line="226"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="417"/>
+        <location filename="src/reportoptionsdialog.ui" line="231"/>
         <source>Column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="422"/>
+        <location filename="src/reportoptionsdialog.ui" line="236"/>
         <source>Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="435"/>
+        <location filename="src/reportoptionsdialog.ui" line="34"/>
         <source>Save as default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="442"/>
+        <location filename="src/reportoptionsdialog.ui" line="41"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="461"/>
+        <location filename="src/reportoptionsdialog.ui" line="407"/>
         <source>Start list is sorted first by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="467"/>
+        <location filename="src/reportoptionsdialog.ui" line="413"/>
         <source>(class name, start time, runner name)</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(class name, start time,  runner name)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="477"/>
+        <location filename="src/reportoptionsdialog.ui" line="423"/>
         <source>(start time, class name, runner name)</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(start time, class name, runner name)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="480"/>
+        <location filename="src/reportoptionsdialog.ui" line="426"/>
         <source>Start times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="487"/>
+        <location filename="src/reportoptionsdialog.ui" line="433"/>
         <source>(runner name, class name, start time)</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(runner name, class name, start time)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="490"/>
+        <location filename="src/reportoptionsdialog.ui" line="436"/>
         <source>Runner names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="513"/>
+        <location filename="src/reportoptionsdialog.ui" line="381"/>
         <source>Start time format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="519"/>
+        <location filename="src/reportoptionsdialog.ui" line="387"/>
         <source>start at 0 (mmm.ss)  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="529"/>
+        <location filename="src/reportoptionsdialog.ui" line="397"/>
         <source>daytime (hh:mm:ss)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/libquickevent/libquickeventgui/libquickeventgui-pl_PL.ts
+++ b/libquickevent/libquickeventgui/libquickeventgui-pl_PL.ts
@@ -9,229 +9,239 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="32"/>
+        <location filename="src/reportoptionsdialog.ui" line="247"/>
         <source>Legs count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="38"/>
+        <location filename="src/reportoptionsdialog.ui" line="253"/>
         <source>Number of legs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="51"/>
+        <location filename="src/reportoptionsdialog.ui" line="60"/>
         <source>Stages count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="57"/>
+        <location filename="src/reportoptionsdialog.ui" line="66"/>
         <source>Number of stages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="70"/>
+        <location filename="src/reportoptionsdialog.ui" line="266"/>
         <source>Class filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="94"/>
+        <location filename="src/reportoptionsdialog.ui" line="290"/>
         <source>Doesn&apos;t match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="101"/>
+        <location filename="src/reportoptionsdialog.ui" line="297"/>
         <source>An question mark (?) in pattern stands for (matches) any single character; a asterisk (*) matches any sequence of zero or more characters.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="104"/>
+        <location filename="src/reportoptionsdialog.ui" line="300"/>
         <source>Wild card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="114"/>
+        <location filename="src/reportoptionsdialog.ui" line="310"/>
         <source>Posix regular expression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="117"/>
+        <location filename="src/reportoptionsdialog.ui" line="313"/>
         <source>RegExp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="124"/>
+        <location filename="src/reportoptionsdialog.ui" line="320"/>
         <source>Coma delimited list of class names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="127"/>
-        <location filename="src/reportoptionsdialog.ui" line="470"/>
+        <location filename="src/reportoptionsdialog.ui" line="323"/>
+        <location filename="src/reportoptionsdialog.ui" line="416"/>
         <source>Class names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="140"/>
+        <location filename="src/reportoptionsdialog.ui" line="446"/>
         <source>Starters options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="158"/>
+        <location filename="src/reportoptionsdialog.ui" line="464"/>
         <source>Space after line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="168"/>
+        <location filename="src/reportoptionsdialog.ui" line="474"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="181"/>
+        <location filename="src/reportoptionsdialog.ui" line="539"/>
+        <source>Relay options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="src/reportoptionsdialog.ui" line="545"/>
+        <source>Show legs details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="src/reportoptionsdialog.ui" line="336"/>
         <source>Start options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="199"/>
+        <location filename="src/reportoptionsdialog.ui" line="354"/>
         <source>Print vacants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="206"/>
+        <location filename="src/reportoptionsdialog.ui" line="361"/>
         <source>Print start numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="213"/>
+        <location filename="src/reportoptionsdialog.ui" line="368"/>
         <source>Use only class from selected start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="226"/>
+        <location filename="src/reportoptionsdialog.ui" line="487"/>
         <source>Result options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="232"/>
+        <location filename="src/reportoptionsdialog.ui" line="493"/>
         <source>Number of places in each class</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="255"/>
+        <location filename="src/reportoptionsdialog.ui" line="516"/>
         <source>Exclude DISQ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="265"/>
+        <location filename="src/reportoptionsdialog.ui" line="79"/>
         <source>Page layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="283"/>
+        <location filename="src/reportoptionsdialog.ui" line="97"/>
         <source>Horizontal margin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="290"/>
-        <location filename="src/reportoptionsdialog.ui" line="336"/>
-        <location filename="src/reportoptionsdialog.ui" line="359"/>
-        <location filename="src/reportoptionsdialog.ui" line="385"/>
+        <location filename="src/reportoptionsdialog.ui" line="104"/>
+        <location filename="src/reportoptionsdialog.ui" line="150"/>
+        <location filename="src/reportoptionsdialog.ui" line="173"/>
+        <location filename="src/reportoptionsdialog.ui" line="199"/>
         <source> mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="322"/>
+        <location filename="src/reportoptionsdialog.ui" line="136"/>
         <source>Column count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="329"/>
+        <location filename="src/reportoptionsdialog.ui" line="143"/>
         <source>Vertical margin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="352"/>
+        <location filename="src/reportoptionsdialog.ui" line="166"/>
         <source>Page width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="378"/>
+        <location filename="src/reportoptionsdialog.ui" line="192"/>
         <source>Page height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="404"/>
+        <location filename="src/reportoptionsdialog.ui" line="218"/>
         <source>Break type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="412"/>
+        <location filename="src/reportoptionsdialog.ui" line="226"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="417"/>
+        <location filename="src/reportoptionsdialog.ui" line="231"/>
         <source>Column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="422"/>
+        <location filename="src/reportoptionsdialog.ui" line="236"/>
         <source>Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="435"/>
+        <location filename="src/reportoptionsdialog.ui" line="34"/>
         <source>Save as default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="442"/>
+        <location filename="src/reportoptionsdialog.ui" line="41"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="461"/>
+        <location filename="src/reportoptionsdialog.ui" line="407"/>
         <source>Start list is sorted first by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="467"/>
+        <location filename="src/reportoptionsdialog.ui" line="413"/>
         <source>(class name, start time, runner name)</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(class name, start time,  runner name)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="477"/>
+        <location filename="src/reportoptionsdialog.ui" line="423"/>
         <source>(start time, class name, runner name)</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(start time, class name, runner name)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="480"/>
+        <location filename="src/reportoptionsdialog.ui" line="426"/>
         <source>Start times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="487"/>
+        <location filename="src/reportoptionsdialog.ui" line="433"/>
         <source>(runner name, class name, start time)</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(runner name, class name, start time)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="490"/>
+        <location filename="src/reportoptionsdialog.ui" line="436"/>
         <source>Runner names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="513"/>
+        <location filename="src/reportoptionsdialog.ui" line="381"/>
         <source>Start time format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="519"/>
+        <location filename="src/reportoptionsdialog.ui" line="387"/>
         <source>start at 0 (mmm.ss)  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="529"/>
+        <location filename="src/reportoptionsdialog.ui" line="397"/>
         <source>daytime (hh:mm:ss)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/libquickevent/libquickeventgui/libquickeventgui-ru_RU.ts
+++ b/libquickevent/libquickeventgui/libquickeventgui-ru_RU.ts
@@ -9,229 +9,239 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="32"/>
+        <location filename="src/reportoptionsdialog.ui" line="247"/>
         <source>Legs count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="38"/>
+        <location filename="src/reportoptionsdialog.ui" line="253"/>
         <source>Number of legs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="51"/>
+        <location filename="src/reportoptionsdialog.ui" line="60"/>
         <source>Stages count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="57"/>
+        <location filename="src/reportoptionsdialog.ui" line="66"/>
         <source>Number of stages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="70"/>
+        <location filename="src/reportoptionsdialog.ui" line="266"/>
         <source>Class filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="94"/>
+        <location filename="src/reportoptionsdialog.ui" line="290"/>
         <source>Doesn&apos;t match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="101"/>
+        <location filename="src/reportoptionsdialog.ui" line="297"/>
         <source>An question mark (?) in pattern stands for (matches) any single character; a asterisk (*) matches any sequence of zero or more characters.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="104"/>
+        <location filename="src/reportoptionsdialog.ui" line="300"/>
         <source>Wild card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="114"/>
+        <location filename="src/reportoptionsdialog.ui" line="310"/>
         <source>Posix regular expression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="117"/>
+        <location filename="src/reportoptionsdialog.ui" line="313"/>
         <source>RegExp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="124"/>
+        <location filename="src/reportoptionsdialog.ui" line="320"/>
         <source>Coma delimited list of class names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="127"/>
-        <location filename="src/reportoptionsdialog.ui" line="470"/>
+        <location filename="src/reportoptionsdialog.ui" line="323"/>
+        <location filename="src/reportoptionsdialog.ui" line="416"/>
         <source>Class names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="140"/>
+        <location filename="src/reportoptionsdialog.ui" line="446"/>
         <source>Starters options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="158"/>
+        <location filename="src/reportoptionsdialog.ui" line="464"/>
         <source>Space after line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="168"/>
+        <location filename="src/reportoptionsdialog.ui" line="474"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="181"/>
+        <location filename="src/reportoptionsdialog.ui" line="539"/>
+        <source>Relay options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="src/reportoptionsdialog.ui" line="545"/>
+        <source>Show legs details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="src/reportoptionsdialog.ui" line="336"/>
         <source>Start options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="199"/>
+        <location filename="src/reportoptionsdialog.ui" line="354"/>
         <source>Print vacants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="206"/>
+        <location filename="src/reportoptionsdialog.ui" line="361"/>
         <source>Print start numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="213"/>
+        <location filename="src/reportoptionsdialog.ui" line="368"/>
         <source>Use only class from selected start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="226"/>
+        <location filename="src/reportoptionsdialog.ui" line="487"/>
         <source>Result options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="232"/>
+        <location filename="src/reportoptionsdialog.ui" line="493"/>
         <source>Number of places in each class</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="255"/>
+        <location filename="src/reportoptionsdialog.ui" line="516"/>
         <source>Exclude DISQ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="265"/>
+        <location filename="src/reportoptionsdialog.ui" line="79"/>
         <source>Page layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="283"/>
+        <location filename="src/reportoptionsdialog.ui" line="97"/>
         <source>Horizontal margin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="290"/>
-        <location filename="src/reportoptionsdialog.ui" line="336"/>
-        <location filename="src/reportoptionsdialog.ui" line="359"/>
-        <location filename="src/reportoptionsdialog.ui" line="385"/>
+        <location filename="src/reportoptionsdialog.ui" line="104"/>
+        <location filename="src/reportoptionsdialog.ui" line="150"/>
+        <location filename="src/reportoptionsdialog.ui" line="173"/>
+        <location filename="src/reportoptionsdialog.ui" line="199"/>
         <source> mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="322"/>
+        <location filename="src/reportoptionsdialog.ui" line="136"/>
         <source>Column count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="329"/>
+        <location filename="src/reportoptionsdialog.ui" line="143"/>
         <source>Vertical margin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="352"/>
+        <location filename="src/reportoptionsdialog.ui" line="166"/>
         <source>Page width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="378"/>
+        <location filename="src/reportoptionsdialog.ui" line="192"/>
         <source>Page height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="404"/>
+        <location filename="src/reportoptionsdialog.ui" line="218"/>
         <source>Break type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="412"/>
+        <location filename="src/reportoptionsdialog.ui" line="226"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="417"/>
+        <location filename="src/reportoptionsdialog.ui" line="231"/>
         <source>Column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="422"/>
+        <location filename="src/reportoptionsdialog.ui" line="236"/>
         <source>Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="435"/>
+        <location filename="src/reportoptionsdialog.ui" line="34"/>
         <source>Save as default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="442"/>
+        <location filename="src/reportoptionsdialog.ui" line="41"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="461"/>
+        <location filename="src/reportoptionsdialog.ui" line="407"/>
         <source>Start list is sorted first by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="467"/>
+        <location filename="src/reportoptionsdialog.ui" line="413"/>
         <source>(class name, start time, runner name)</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(class name, start time,  runner name)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="477"/>
+        <location filename="src/reportoptionsdialog.ui" line="423"/>
         <source>(start time, class name, runner name)</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(start time, class name, runner name)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="480"/>
+        <location filename="src/reportoptionsdialog.ui" line="426"/>
         <source>Start times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="487"/>
+        <location filename="src/reportoptionsdialog.ui" line="433"/>
         <source>(runner name, class name, start time)</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(runner name, class name, start time)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="490"/>
+        <location filename="src/reportoptionsdialog.ui" line="436"/>
         <source>Runner names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="513"/>
+        <location filename="src/reportoptionsdialog.ui" line="381"/>
         <source>Start time format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="519"/>
+        <location filename="src/reportoptionsdialog.ui" line="387"/>
         <source>start at 0 (mmm.ss)  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="529"/>
+        <location filename="src/reportoptionsdialog.ui" line="397"/>
         <source>daytime (hh:mm:ss)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/libquickevent/libquickeventgui/libquickeventgui-uk_UA.ts
+++ b/libquickevent/libquickeventgui/libquickeventgui-uk_UA.ts
@@ -9,229 +9,239 @@
         <translation>Опції друкування звіту</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="51"/>
+        <location filename="src/reportoptionsdialog.ui" line="60"/>
         <source>Stages count</source>
         <translation>Кількість забігів</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="57"/>
+        <location filename="src/reportoptionsdialog.ui" line="66"/>
         <source>Number of stages</source>
         <translation>Кількість забігів</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="32"/>
+        <location filename="src/reportoptionsdialog.ui" line="247"/>
         <source>Legs count</source>
         <translation>Кількість етапів</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="38"/>
+        <location filename="src/reportoptionsdialog.ui" line="253"/>
         <source>Number of legs</source>
         <translation>Кількість етапів</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="70"/>
+        <location filename="src/reportoptionsdialog.ui" line="266"/>
         <source>Class filter</source>
         <translation>Фільтер груп</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="114"/>
+        <location filename="src/reportoptionsdialog.ui" line="310"/>
         <source>Posix regular expression</source>
         <translation>Регулярний вираз Posix</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="117"/>
+        <location filename="src/reportoptionsdialog.ui" line="313"/>
         <source>RegExp</source>
         <translation>RegExp</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="101"/>
+        <location filename="src/reportoptionsdialog.ui" line="297"/>
         <source>An question mark (?) in pattern stands for (matches) any single character; a asterisk (*) matches any sequence of zero or more characters.</source>
         <translation>Знак питання (?) У шаблоні означає (відповідає) будь-якому окремому символу; зірочка (*) відповідає будь-якій послідовності з нуля або більше символів.</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="104"/>
+        <location filename="src/reportoptionsdialog.ui" line="300"/>
         <source>Wild card</source>
         <translation>Будь-що</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="94"/>
+        <location filename="src/reportoptionsdialog.ui" line="290"/>
         <source>Doesn&apos;t match</source>
         <translation>Не співпадає</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="124"/>
+        <location filename="src/reportoptionsdialog.ui" line="320"/>
         <source>Coma delimited list of class names</source>
         <translation>Список назв груп, розділених комою</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="127"/>
-        <location filename="src/reportoptionsdialog.ui" line="470"/>
+        <location filename="src/reportoptionsdialog.ui" line="323"/>
+        <location filename="src/reportoptionsdialog.ui" line="416"/>
         <source>Class names</source>
         <translation>Назви груп</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="226"/>
+        <location filename="src/reportoptionsdialog.ui" line="487"/>
         <source>Result options</source>
         <translation>Опції результату</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="232"/>
+        <location filename="src/reportoptionsdialog.ui" line="493"/>
         <source>Number of places in each class</source>
         <translation>Кількість місць в кожній групі</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="255"/>
+        <location filename="src/reportoptionsdialog.ui" line="516"/>
         <source>Exclude DISQ</source>
         <translation>Відкинути DISQ</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="140"/>
+        <location filename="src/reportoptionsdialog.ui" line="446"/>
         <source>Starters options</source>
         <translation>Опції учасників</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="158"/>
+        <location filename="src/reportoptionsdialog.ui" line="464"/>
         <source>Space after line</source>
         <translation>Простір після лінії</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="168"/>
+        <location filename="src/reportoptionsdialog.ui" line="474"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="181"/>
+        <location filename="src/reportoptionsdialog.ui" line="336"/>
         <source>Start options</source>
         <translation>Опції старту</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="199"/>
+        <location filename="src/reportoptionsdialog.ui" line="354"/>
         <source>Print vacants</source>
         <translation>Друкувати незайняті</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="206"/>
+        <location filename="src/reportoptionsdialog.ui" line="361"/>
         <source>Print start numbers</source>
         <translation>Друкувати стартові номери</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="442"/>
+        <location filename="src/reportoptionsdialog.ui" line="41"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="461"/>
+        <location filename="src/reportoptionsdialog.ui" line="407"/>
         <source>Start list is sorted first by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="467"/>
+        <location filename="src/reportoptionsdialog.ui" line="413"/>
         <source>(class name, start time, runner name)</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(class name, start time,  runner name)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="477"/>
+        <location filename="src/reportoptionsdialog.ui" line="423"/>
         <source>(start time, class name, runner name)</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(start time, class name, runner name)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="480"/>
+        <location filename="src/reportoptionsdialog.ui" line="426"/>
         <source>Start times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="487"/>
+        <location filename="src/reportoptionsdialog.ui" line="433"/>
         <source>(runner name, class name, start time)</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(runner name, class name, start time)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="490"/>
+        <location filename="src/reportoptionsdialog.ui" line="436"/>
         <source>Runner names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="513"/>
+        <location filename="src/reportoptionsdialog.ui" line="381"/>
         <source>Start time format</source>
         <translation>Формат часу початку</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="519"/>
+        <location filename="src/reportoptionsdialog.ui" line="387"/>
         <source>start at 0 (mmm.ss)  </source>
         <translation>починати з 0 (хвл.ск)  </translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="529"/>
+        <location filename="src/reportoptionsdialog.ui" line="397"/>
         <source>daytime (hh:mm:ss)</source>
         <translation>час дня (гг:хв:ск)</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="265"/>
+        <location filename="src/reportoptionsdialog.ui" line="79"/>
         <source>Page layout</source>
         <translation>Орієнтація сторінки</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="213"/>
+        <location filename="src/reportoptionsdialog.ui" line="368"/>
         <source>Use only class from selected start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="283"/>
+        <location filename="src/reportoptionsdialog.ui" line="97"/>
         <source>Horizontal margin</source>
         <translation>Горизотальний відступ</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="290"/>
-        <location filename="src/reportoptionsdialog.ui" line="336"/>
-        <location filename="src/reportoptionsdialog.ui" line="359"/>
-        <location filename="src/reportoptionsdialog.ui" line="385"/>
+        <location filename="src/reportoptionsdialog.ui" line="104"/>
+        <location filename="src/reportoptionsdialog.ui" line="150"/>
+        <location filename="src/reportoptionsdialog.ui" line="173"/>
+        <location filename="src/reportoptionsdialog.ui" line="199"/>
         <source> mm</source>
         <translation> мм</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="322"/>
+        <location filename="src/reportoptionsdialog.ui" line="136"/>
         <source>Column count</source>
         <translation>К-сть стовпців</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="329"/>
+        <location filename="src/reportoptionsdialog.ui" line="143"/>
         <source>Vertical margin</source>
         <translation>Вертикальний відступ</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="352"/>
+        <location filename="src/reportoptionsdialog.ui" line="166"/>
         <source>Page width</source>
         <translation>Ширина сторінки</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="378"/>
+        <location filename="src/reportoptionsdialog.ui" line="192"/>
         <source>Page height</source>
         <translation>Висота сторінки</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="404"/>
+        <location filename="src/reportoptionsdialog.ui" line="218"/>
         <source>Break type</source>
         <translation>Тип розриву</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="412"/>
+        <location filename="src/reportoptionsdialog.ui" line="226"/>
         <source>None</source>
         <translation>Немає</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="417"/>
+        <location filename="src/reportoptionsdialog.ui" line="231"/>
         <source>Column</source>
         <translation>Стовпець</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="422"/>
+        <location filename="src/reportoptionsdialog.ui" line="236"/>
         <source>Page</source>
         <translation>Сторінка</translation>
     </message>
     <message>
-        <location filename="src/reportoptionsdialog.ui" line="435"/>
+        <location filename="src/reportoptionsdialog.ui" line="539"/>
+        <source>Relay options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="src/reportoptionsdialog.ui" line="545"/>
+        <source>Show legs details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="src/reportoptionsdialog.ui" line="34"/>
         <source>Save as default</source>
         <translation>Зберегти як початкові</translation>
     </message>

--- a/libquickevent/libquickeventgui/src/reportoptionsdialog.cpp
+++ b/libquickevent/libquickeventgui/src/reportoptionsdialog.cpp
@@ -39,6 +39,7 @@ ReportOptionsDialog::ReportOptionsDialog(QWidget *parent)
 	ui->grpResultOptions->setVisible(false);
 	ui->grpStartTimes->setVisible(false);
 	ui->grpStartlistOrderBy->setVisible(false);
+	ui->grpRelayOptions->setVisible(false);
 	ui->btRegExp->setEnabled(QSqlDatabase::database().driverName().endsWith(QLatin1String("PSQL"), Qt::CaseInsensitive));
 
 	{

--- a/libquickevent/libquickeventgui/src/reportoptionsdialog.cpp
+++ b/libquickevent/libquickeventgui/src/reportoptionsdialog.cpp
@@ -73,6 +73,8 @@ ReportOptionsDialog::ReportOptionsDialog(QWidget *parent)
 	connect(this, &ReportOptionsDialog::resultOptionsVisibleChanged, ui->grpResultOptions, &QGroupBox::setVisible);
 	connect(this, &ReportOptionsDialog::startTimeFormatVisibleChanged, ui->grpStartTimes, &QGroupBox::setVisible);
 	connect(this, &ReportOptionsDialog::startlistOrderFirstByVisibleChanged, ui->grpStartlistOrderBy, &QGroupBox::setVisible);
+	connect(this, &ReportOptionsDialog::relayOptionsVisibleChanged, ui->grpRelayOptions, &QGroupBox::setVisible);
+
 }
 
 ReportOptionsDialog::~ReportOptionsDialog()
@@ -253,6 +255,7 @@ void ReportOptionsDialog::setOptions(const ReportOptionsDialog::Options &options
 	ui->btStartOrder1->setChecked(start_order_by == StartlistOrderFirstBy::ClassName);
 	ui->btStartOrder2->setChecked(start_order_by == StartlistOrderFirstBy::StartTime);
 	ui->btStartOrder3->setChecked(start_order_by == StartlistOrderFirstBy::Names);
+	ui->chkRelayOpts_ShowLegs->setChecked(options.isRelayShowLegsDetails());
 }
 
 ReportOptionsDialog::Options ReportOptionsDialog::options() const
@@ -287,6 +290,8 @@ ReportOptionsDialog::Options ReportOptionsDialog::options() const
 	opts.setStartTimeFormat((int)start_time_format);
 	StartlistOrderFirstBy start_order_by = startlistOrderFirstBy();
 	opts.setStartlistOrderFirstBy((int)start_order_by);
+	opts.setRelayShowLegsDetails(ui->chkRelayOpts_ShowLegs->isChecked());
+
 	return opts;
 }
 
@@ -372,6 +377,16 @@ void ReportOptionsDialog::resetPersistentSettings()
     setOptions(new_options);
     savePersistentSettings();
 }
+
+void ReportOptionsDialog::setStartListForRelays()
+{
+	setStartListOptionsVisible(true);
+	setVacantsVisible(true);
+	ui->chkStartOpts_PrintStartNumbers->setVisible(false);
+	ui->lblStartNumber->setVisible(false);
+	ui->cbxStartNumber->setVisible(false);
+}
+
 
 }
 

--- a/libquickevent/libquickeventgui/src/reportoptionsdialog.h
+++ b/libquickevent/libquickeventgui/src/reportoptionsdialog.h
@@ -33,6 +33,7 @@ class QUICKEVENTGUI_DECL_EXPORT ReportOptionsDialog : public QDialog, public qf:
 	Q_PROPERTY(bool startTimeFormatVisible READ isStartTimeFormatVisible WRITE setStartTimeFormatVisible NOTIFY startTimeFormatVisibleChanged)
 	Q_PROPERTY(bool startlistOrderFirstByVisible READ isStartlistOrderFirstByVisible WRITE setStartlistOrderFirstByVisible NOTIFY startlistOrderFirstByVisibleChanged)
 	//Q_PROPERTY(bool classStartSelectionVisible READ isClassStartSelectionVisible WRITE setClassStartSelectionVisible NOTIFY classStartSelectionVisibleChanged)
+	Q_PROPERTY(bool relayOptionsVisible READ isRelayOptionsVisible WRITE setRelayOptionsVisible NOTIFY relayOptionsVisibleChanged)
 
 	QF_PROPERTY_BOOL_IMPL2(c, C, lassFilterVisible, true)
 	QF_PROPERTY_BOOL_IMPL2(s, S, tartListOptionsVisible, false)
@@ -45,6 +46,7 @@ class QUICKEVENTGUI_DECL_EXPORT ReportOptionsDialog : public QDialog, public qf:
 	QF_PROPERTY_BOOL_IMPL2(r, R, esultOptionsVisible, false)
 	QF_PROPERTY_BOOL_IMPL2(s, S, tartTimeFormatVisible, false)
 	QF_PROPERTY_BOOL_IMPL2(s, S, tartlistOrderFirstByVisible, false)
+	QF_PROPERTY_BOOL_IMPL2(r, R, elayOptionsVisible, false)
 private:
 	using Super = QDialog;
 public:
@@ -76,6 +78,7 @@ public:
 		QF_VARIANTMAP_FIELD2(int, s, setS, tartTimeFormat, 0)
 		QF_VARIANTMAP_FIELD2(int, s, setS, tartlistOrderFirstBy, 0)
 		QF_VARIANTMAP_FIELD2(int, s, setS, tartNumber, 0)
+		QF_VARIANTMAP_FIELD2(bool, isR, setR, elayShowLegsDetails, true)
 		public:
 			Options(const QVariantMap &o = QVariantMap()) : QVariantMap(o) {}
 	};
@@ -86,6 +89,7 @@ public:
 	int exec() Q_DECL_OVERRIDE;
 
 	void setStartListPrintVacantsVisible(bool b);
+	void setStartListForRelays();
 
 	QString persistentSettingsPath() Q_DECL_OVERRIDE;
 	bool setPersistentSettingsId(const QString &id) Q_DECL_OVERRIDE;

--- a/libquickevent/libquickeventgui/src/reportoptionsdialog.ui
+++ b/libquickevent/libquickeventgui/src/reportoptionsdialog.ui
@@ -26,24 +26,33 @@
    <property name="bottomMargin">
     <number>5</number>
    </property>
-   <item row="1" column="0">
-    <widget class="QGroupBox" name="grpLegs">
-     <property name="title">
-      <string>Legs count</string>
-     </property>
-     <layout class="QFormLayout" name="formLayout_3">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_10">
-        <property name="text">
-         <string>Number of legs</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QSpinBox" name="edLegsCount"/>
-      </item>
-     </layout>
-    </widget>
+   <item row="11" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QPushButton" name="btSaveAsDefault">
+       <property name="text">
+        <string>Save as default</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btReset">
+       <property name="text">
+        <string>Reset</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="grpStages">
@@ -64,202 +73,7 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="grpClassFilter">
-     <property name="title">
-      <string>Class filter</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <property name="leftMargin">
-       <number>5</number>
-      </property>
-      <property name="topMargin">
-       <number>5</number>
-      </property>
-      <property name="rightMargin">
-       <number>5</number>
-      </property>
-      <property name="bottomMargin">
-       <number>5</number>
-      </property>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="chkClassFilterDoesntMatch">
-        <property name="text">
-         <string>Doesn't match</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QRadioButton" name="btWildCard">
-        <property name="toolTip">
-         <string>An question mark (?) in pattern stands for (matches) any single character; a asterisk (*) matches any sequence of zero or more characters.</string>
-        </property>
-        <property name="text">
-         <string>Wild card</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QRadioButton" name="btRegExp">
-        <property name="toolTip">
-         <string>Posix regular expression</string>
-        </property>
-        <property name="text">
-         <string>RegExp</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QRadioButton" name="btClassNames">
-        <property name="toolTip">
-         <string>Coma delimited list of class names</string>
-        </property>
-        <property name="text">
-         <string>Class names</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="3">
-       <widget class="QLineEdit" name="edFilter"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QGroupBox" name="grpStartersOptions">
-     <property name="title">
-      <string>Starters options</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_3">
-      <property name="leftMargin">
-       <number>5</number>
-      </property>
-      <property name="topMargin">
-       <number>5</number>
-      </property>
-      <property name="rightMargin">
-       <number>5</number>
-      </property>
-      <property name="bottomMargin">
-       <number>5</number>
-      </property>
-      <item>
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Space after line</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QSpinBox" name="edStartersOptionsLineSpacing">
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-        <property name="suffix">
-         <string>mm</string>
-        </property>
-        <property name="maximum">
-         <number>100</number>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QGroupBox" name="grpStartOptions">
-     <property name="title">
-      <string>Start options</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_4">
-      <property name="leftMargin">
-       <number>5</number>
-      </property>
-      <property name="topMargin">
-       <number>5</number>
-      </property>
-      <property name="rightMargin">
-       <number>5</number>
-      </property>
-      <property name="bottomMargin">
-       <number>5</number>
-      </property>
-      <item row="1" column="1">
-       <widget class="QCheckBox" name="chkStartOpts_PrintVacants">
-        <property name="text">
-         <string>Print vacants</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QCheckBox" name="chkStartOpts_PrintStartNumbers">
-        <property name="text">
-         <string>Print start numbers</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="label_11">
-        <property name="text">
-         <string>Use only class from selected start</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QComboBox" name="cbxStartNumber"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QGroupBox" name="grpResultOptions">
-     <property name="title">
-      <string>Result options</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_41">
-      <item>
-       <widget class="QLabel" name="label_9">
-        <property name="text">
-         <string>Number of places in each class</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QSpinBox" name="edNumPlaces">
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>9999</number>
-        </property>
-        <property name="value">
-         <number>9999</number>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="chkExcludeDisq">
-        <property name="text">
-         <string>Exclude DISQ</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="8" column="0">
+   <item row="9" column="0">
     <widget class="QGroupBox" name="grpPageLayout">
      <property name="title">
       <string>Page layout</string>
@@ -303,7 +117,7 @@
       <item row="3" column="1">
        <widget class="QSpinBox" name="edColumnCount">
         <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
         </property>
         <property name="minimum">
          <number>1</number>
@@ -427,33 +241,165 @@
      </layout>
     </widget>
    </item>
-   <item row="10" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QPushButton" name="btSaveAsDefault">
-       <property name="text">
-        <string>Save as default</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btReset">
-       <property name="text">
-        <string>Reset</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="grpLegs">
+     <property name="title">
+      <string>Legs count</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_10">
+        <property name="text">
+         <string>Number of legs</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="edLegsCount"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="grpClassFilter">
+     <property name="title">
+      <string>Class filter</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="leftMargin">
+       <number>5</number>
+      </property>
+      <property name="topMargin">
+       <number>5</number>
+      </property>
+      <property name="rightMargin">
+       <number>5</number>
+      </property>
+      <property name="bottomMargin">
+       <number>5</number>
+      </property>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="chkClassFilterDoesntMatch">
+        <property name="text">
+         <string>Doesn't match</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QRadioButton" name="btWildCard">
+        <property name="toolTip">
+         <string>An question mark (?) in pattern stands for (matches) any single character; a asterisk (*) matches any sequence of zero or more characters.</string>
+        </property>
+        <property name="text">
+         <string>Wild card</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QRadioButton" name="btRegExp">
+        <property name="toolTip">
+         <string>Posix regular expression</string>
+        </property>
+        <property name="text">
+         <string>RegExp</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QRadioButton" name="btClassNames">
+        <property name="toolTip">
+         <string>Coma delimited list of class names</string>
+        </property>
+        <property name="text">
+         <string>Class names</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="3">
+       <widget class="QLineEdit" name="edFilter"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QGroupBox" name="grpStartOptions">
+     <property name="title">
+      <string>Start options</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <property name="leftMargin">
+       <number>5</number>
+      </property>
+      <property name="topMargin">
+       <number>5</number>
+      </property>
+      <property name="rightMargin">
+       <number>5</number>
+      </property>
+      <property name="bottomMargin">
+       <number>5</number>
+      </property>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="chkStartOpts_PrintVacants">
+        <property name="text">
+         <string>Print vacants</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QCheckBox" name="chkStartOpts_PrintStartNumbers">
+        <property name="text">
+         <string>Print start numbers</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="lblStartNumber">
+        <property name="text">
+         <string>Use only class from selected start</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QComboBox" name="cbxStartNumber"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QGroupBox" name="grpStartTimes">
+     <property name="title">
+      <string>Start time format</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <item>
+       <widget class="QRadioButton" name="btStartTimes1">
+        <property name="text">
+         <string>start at 0 (mmm.ss)  </string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="btStartTimes2">
+        <property name="text">
+         <string>daytime (hh:mm:ss)</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item row="7" column="0">
     <widget class="QGroupBox" name="grpStartlistOrderBy">
@@ -494,10 +440,90 @@
      </layout>
     </widget>
    </item>
-   <item row="9" column="0">
+   <item row="4" column="0">
+    <widget class="QGroupBox" name="grpStartersOptions">
+     <property name="title">
+      <string>Starters options</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <property name="leftMargin">
+       <number>5</number>
+      </property>
+      <property name="topMargin">
+       <number>5</number>
+      </property>
+      <property name="rightMargin">
+       <number>5</number>
+      </property>
+      <property name="bottomMargin">
+       <number>5</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Space after line</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="edStartersOptionsLineSpacing">
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+        </property>
+        <property name="suffix">
+         <string>mm</string>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QGroupBox" name="grpResultOptions">
+     <property name="title">
+      <string>Result options</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_41">
+      <item>
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>Number of places in each class</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="edNumPlaces">
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>9999</number>
+        </property>
+        <property name="value">
+         <number>9999</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="chkExcludeDisq">
+        <property name="text">
+         <string>Exclude DISQ</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="10" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -507,26 +533,19 @@
      </property>
     </spacer>
    </item>
-   <item row="6" column="0">
-    <widget class="QGroupBox" name="grpStartTimes">
+   <item row="8" column="0">
+    <widget class="QGroupBox" name="grpRelayOptions">
      <property name="title">
-      <string>Start time format</string>
+      <string>Relay options</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <widget class="QRadioButton" name="btStartTimes1">
+       <widget class="QCheckBox" name="chkRelayOpts_ShowLegs">
         <property name="text">
-         <string>start at 0 (mmm.ss)  </string>
+         <string>Show legs details</string>
         </property>
         <property name="checked">
          <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="btStartTimes2">
-        <property name="text">
-         <string>daytime (hh:mm:ss)</string>
         </property>
        </widget>
       </item>
@@ -547,6 +566,7 @@
   <tabstop>edNumPlaces</tabstop>
   <tabstop>chkExcludeDisq</tabstop>
   <tabstop>edStartersOptionsLineSpacing</tabstop>
+  <tabstop>cbxStartNumber</tabstop>
   <tabstop>chkStartOpts_PrintVacants</tabstop>
   <tabstop>chkStartOpts_PrintStartNumbers</tabstop>
   <tabstop>btStartTimes1</tabstop>
@@ -554,6 +574,7 @@
   <tabstop>btStartOrder1</tabstop>
   <tabstop>btStartOrder2</tabstop>
   <tabstop>btStartOrder3</tabstop>
+  <tabstop>chkRelayOpts_ShowLegs</tabstop>
   <tabstop>edPageWidth</tabstop>
   <tabstop>edHorizontalMargin</tabstop>
   <tabstop>edColumnCount</tabstop>

--- a/quickevent/app/quickevent/CMakeLists.txt
+++ b/quickevent/app/quickevent/CMakeLists.txt
@@ -211,6 +211,8 @@ add_executable(quickevent
 	plugins/Relays/qml/reports/results_condensed.qml
 	plugins/Relays/qml/reports/startList_classes.qml
 	plugins/Relays/qml/reports/startList_clubs.qml
+	plugins/Relays/qml/reports/startList_classes_condensed.qml
+	plugins/Relays/qml/reports/startList_clubs_condensed.qml
 
 	plugins/Runs/qml/reports/competitorsWithCardRent.qml
 	plugins/Runs/qml/reports/results_nstages.qml

--- a/quickevent/app/quickevent/plugins/Classes/src/classeswidget.cpp
+++ b/quickevent/app/quickevent/plugins/Classes/src/classeswidget.cpp
@@ -363,10 +363,10 @@ void ClassesWidget::reload()
 				, qf::core::sql::QueryBuilder::INNER_JOIN);
 		qfDebug() << qb1.toString();
 		qf::core::sql::QueryBuilder qb2;
-		qb2.select("COUNT(relays.isRunning)")
+		qb2.select("COUNT(relays.isRelRunning)")
 			.from("relays")
 			.where("relays.classId=classdefs.classId"
-							" AND relays.isRunning");
+							" AND relays.isRelRunning");
 		qfDebug() << qb2.toString();
 		qfs::QueryBuilder qb;
 		qb.select2("classes", "*")

--- a/quickevent/app/quickevent/plugins/Classes/src/classeswidget.cpp
+++ b/quickevent/app/quickevent/plugins/Classes/src/classeswidget.cpp
@@ -363,10 +363,10 @@ void ClassesWidget::reload()
 				, qf::core::sql::QueryBuilder::INNER_JOIN);
 		qfDebug() << qb1.toString();
 		qf::core::sql::QueryBuilder qb2;
-		qb2.select("COUNT(relays.isRelRunning)")
+		qb2.select("COUNT(relays.isRunning)")
 			.from("relays")
 			.where("relays.classId=classdefs.classId"
-							" AND relays.isRelRunning");
+							" AND relays.isRunning");
 		qfDebug() << qb2.toString();
 		qfs::QueryBuilder qb;
 		qb.select2("classes", "*")

--- a/quickevent/app/quickevent/plugins/Classes/src/classeswidget.cpp
+++ b/quickevent/app/quickevent/plugins/Classes/src/classeswidget.cpp
@@ -454,6 +454,11 @@ static QString normalize_course_name(const QString &course_name)
 
 void ClassesWidget::import_ocad_txt()
 {
+	if (getPlugin<EventPlugin>()->eventConfig()->isRelays()) {
+		QMessageBox::warning(this,tr("Warning"),tr("Import does not yet support relays."));
+		return;
+	}
+
 	QString fn = qfd::FileDialog::getOpenFileName(this, tr("Open file"));
 	if(fn.isEmpty())
 		return;
@@ -630,6 +635,11 @@ static QString dump_element(const QDomElement &el)
 
 void ClassesWidget::import_ocad_iofxml_2()
 {
+	if (getPlugin<EventPlugin>()->eventConfig()->isRelays()) {
+		QMessageBox::warning(this,tr("Warning"),tr("Import does not yet support relays."));
+		return;
+	}
+
 	qfLogFuncFrame();
 	QString fn = qfd::FileDialog::getOpenFileName(this, tr("Open file"), QString(), tr("XML files (*.xml);; All files (*)"));
 	if(fn.isEmpty())
@@ -699,6 +709,11 @@ void ClassesWidget::import_ocad_iofxml_2()
 
 void ClassesWidget::import_ocad_iofxml_3()
 {
+	if (getPlugin<EventPlugin>()->eventConfig()->isRelays()) {
+		QMessageBox::warning(this,tr("Warning"),tr("Import does not yet support relays."));
+		return;
+	}
+
 	qfLogFuncFrame();
 	//static constexpr int START_CODE0 = 0;
 	//static const int FINISH_CODE0 = quickevent::core::CodeDef::FINISH_PUNCH_CODE - 1;

--- a/quickevent/app/quickevent/plugins/Classes/src/classeswidget.cpp
+++ b/quickevent/app/quickevent/plugins/Classes/src/classeswidget.cpp
@@ -192,6 +192,7 @@ ClassesWidget::ClassesWidget(QWidget *parent) :
 		//m->addColumn("courses.name", tr("Course")).setReadOnly(true);
 		m->addColumn("courses.length", tr("Length"));
 		m->addColumn("courses.climb", tr("Climb"));
+		m->addColumn("relaysCount", tr("Count")).setToolTip(tr("Relays count"));
 		m->addColumn("classdefs.relayStartNumber", tr("Rel.num")).setToolTip(tr("Relay start number"));
 		m->addColumn("classdefs.relayLegCount", tr("Legs")).setToolTip(tr("Relay leg count"));
 		ui->tblClasses->setTableModel(m);
@@ -361,11 +362,18 @@ void ClassesWidget::reload()
 								" AND runs.stageId=" QF_IARG(stage_id)
 				, qf::core::sql::QueryBuilder::INNER_JOIN);
 		qfDebug() << qb1.toString();
+		qf::core::sql::QueryBuilder qb2;
+		qb2.select("COUNT(relays.isRunning)")
+			.from("relays")
+			.where("relays.classId=classdefs.classId"
+							" AND relays.isRunning");
+		qfDebug() << qb2.toString();
 		qfs::QueryBuilder qb;
 		qb.select2("classes", "*")
 				.select2("classdefs", "*")
 				.select2("courses", "id, name, length, climb")
 				.select("(" + qb1.toString() + ") AS runsCount")
+				.select("(" + qb2.toString() + ") AS relaysCount")
 				.from("classes")
 				.joinRestricted("classes.id", "classdefs.classId", "classdefs.stageId=" QF_IARG(stage_id))
 				.join("classdefs.courseId", "courses.id")

--- a/quickevent/app/quickevent/plugins/Event/qml/DbSchema.qml
+++ b/quickevent/app/quickevent/plugins/Event/qml/DbSchema.qml
@@ -305,7 +305,11 @@ Schema {
 				Field { name: 'club'; type: String {} },
 				Field { name: 'name'; type: String {} },
 				Field { name: 'note'; type: String {} },
-				Field { name: 'importId'; type: Int {} }
+				Field { name: 'importId'; type: Int {} },
+				Field { name: 'isRunning'; type: Boolean { }
+					defaultValue: true;
+					notNull: true
+				}
 			]
 			indexes: [
 				Index {fields: ['classId']; references: ForeignKeyReference {table: 'classes'; fields: ['id']; } },

--- a/quickevent/app/quickevent/plugins/Event/qml/DbSchema.qml
+++ b/quickevent/app/quickevent/plugins/Event/qml/DbSchema.qml
@@ -306,7 +306,7 @@ Schema {
 				Field { name: 'name'; type: String {} },
 				Field { name: 'note'; type: String {} },
 				Field { name: 'importId'; type: Int {} },
-				Field { name: 'isRelRunning'; type: Boolean { }
+				Field { name: 'isRunning'; type: Boolean { }
 					defaultValue: true;
 					notNull: true
 				}

--- a/quickevent/app/quickevent/plugins/Event/qml/DbSchema.qml
+++ b/quickevent/app/quickevent/plugins/Event/qml/DbSchema.qml
@@ -306,7 +306,7 @@ Schema {
 				Field { name: 'name'; type: String {} },
 				Field { name: 'note'; type: String {} },
 				Field { name: 'importId'; type: Int {} },
-				Field { name: 'isRunning'; type: Boolean { }
+				Field { name: 'isRelRunning'; type: Boolean { }
 					defaultValue: true;
 					notNull: true
 				}

--- a/quickevent/app/quickevent/plugins/Event/src/services/emmaclient.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/emmaclient.cpp
@@ -417,7 +417,7 @@ void EmmaClient::exportStartListRacomTxt() const
 			.join("runs.id", "cards.runId")
 			.where("runs.stageId=" QF_IARG(current_stage));
 	if(is_relays) {
-		qb.select2("relays","number");
+		qb.select2("relays","number, isrunning");
 		qb.join("runs.relayId", "relays.id");
 		qb.join("relays.classId", "classes.id");
 		qb.orderBy("runs.leg, relays.number ASC");
@@ -438,7 +438,8 @@ void EmmaClient::exportStartListRacomTxt() const
 		if (id == last_id)
 			continue;
 		bool is_running = (q2.value("runs.isrunning").isNull()) ? false : q2.value("runs.isrunning").toBool();
-		if (!is_running)
+		bool is_rel_running = (q2.value("relays.isrunning").isNull()) ? false : q2.value("relays.isrunning").toBool();
+		if (!is_running || !is_rel_running)
 			continue;
 		last_id = id;
 		int si = q2.value("runs.siId").toInt();
@@ -545,7 +546,7 @@ void EmmaClient::exportStartListRacomCsv() const
 		.join("runs.id", "cards.runId")
 		.where("runs.stageId=" QF_IARG(current_stage));
 	if(is_relays) {
-		qb.select2("relays","number");
+		qb.select2("relays","number, isrunning");
 		qb.join("runs.relayId", "relays.id");
 		qb.join("relays.classId", "classes.id");
 		qb.orderBy("runs.leg, relays.number ASC");
@@ -566,7 +567,8 @@ void EmmaClient::exportStartListRacomCsv() const
 		if (id == last_id)
 			continue;
 		bool is_running = (q2.value("runs.isrunning").isNull()) ? false : q2.value("runs.isrunning").toBool();
-		if (!is_running)
+		bool is_rel_running = (q2.value("relays.isrunning").isNull()) ? false : q2.value("relays.isrunning").toBool();
+		if (!is_running || !is_rel_running)
 			continue;
 		last_id = id;
 		int si = q2.value("runs.siId").toInt();

--- a/quickevent/app/quickevent/plugins/Oris/src/orisimporter.cpp
+++ b/quickevent/app/quickevent/plugins/Oris/src/orisimporter.cpp
@@ -410,6 +410,7 @@ void OrisImporter::importEvent(int event_id, std::function<void ()> success_call
 			if(!getPlugin<EventPlugin>()->createEvent(QString(), ecfg))
 				return;
 
+			bool is_relay = getPlugin<EventPlugin>()->eventConfig()->isRelays();
 			//QString event_name = getPlugin<EventPlugin>()->eventName();
 			qfLogScope("importEvent");
 			qf::core::sql::Transaction transaction;
@@ -431,6 +432,15 @@ void OrisImporter::importEvent(int event_id, std::function<void ()> success_call
 				doc.setValue("id", class_id);
 				doc.setValue("name", class_name);
 				doc.save();
+				if (is_relay) {
+					int legs = class_o.value(QStringLiteral("Legs")).toString().toInt();
+					qf::core::sql::Query q;
+					q.execThrow("UPDATE classdefs SET"
+								" relayLegCount=" + QString::number(legs) +
+								" WHERE classId=" + QString::number(class_id) +
+								" AND stageId=1"
+								);
+				}
 			}
 			transaction.commit();
 			fwk->hideProgress();

--- a/quickevent/app/quickevent/plugins/Receipts/src/receiptsplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Receipts/src/receiptsplugin.cpp
@@ -39,7 +39,6 @@ namespace qff = qf::qmlwidgets::framework;
 using ::PartWidget;
 using qff::getPlugin;
 using Event::EventPlugin;
-using Receipts::ReceiptsPlugin;
 using CardReader::CardReaderPlugin;
 
 namespace Receipts {

--- a/quickevent/app/quickevent/plugins/Receipts/src/receiptsplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Receipts/src/receiptsplugin.cpp
@@ -288,7 +288,7 @@ QVariantMap ReceiptsPlugin::receiptTablesData(int card_id)
 										" AND runs.finishTimeMs > 0"
 										" AND runs.leg=" QF_IARG(leg),
 										qf::core::sql::QueryBuilder::INNER_JOIN)
-						.orderBy("misPunch, disqualified, isRunning, runs.timeMs");
+						.orderBy("misPunch, disqualified, relays.isRunning, runs.isRunning, runs.timeMs");
 			}
 			else {
 				int class_id = model.value(0, "competitors.classId").toInt();
@@ -297,7 +297,7 @@ QVariantMap ReceiptsPlugin::receiptTablesData(int card_id)
 						.from("competitors")
 						.joinRestricted("competitors.id", "runs.competitorId", "runs.stageId=" QF_IARG(stage_id) " AND competitors.classId=" QF_IARG(class_id), qf::core::sql::QueryBuilder::INNER_JOIN)
 						.where("runs.finishTimeMs > 0")
-						.orderBy("misPunch, disqualified, isRunning, runs.timeMs");
+						.orderBy("misPunch, disqualified, runs.isRunning, runs.timeMs");
 			}
 			//qfInfo() << qb.toString();
 			auto q = qf::core::sql::Query::fromExec(qb.toString());

--- a/quickevent/app/quickevent/plugins/Receipts/src/receiptsplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Receipts/src/receiptsplugin.cpp
@@ -29,6 +29,7 @@
 #include <QDomDocument>
 #include <QSqlRecord>
 #include <QPrinterInfo>
+#include <QMessageBox>
 
 //#define QF_TIMESCOPE_ENABLED
 #include <qf/core/utils/timescope.h>
@@ -467,13 +468,18 @@ void ReceiptsPlugin::previewReceipt(int card_id)
 	//qfInfo() << "previewReceipe_classic, card id:" << card_id;
 	ReceiptsSettings settings;
 	auto *w = new qf::qmlwidgets::reports::ReportViewWidget();
+	if (settings.receiptPath().isEmpty()) {
+		auto fwk = qff::MainWindow::frameWork();
+		QMessageBox::warning(fwk,tr("Warning"),tr("Receipt report type is not defined.\nPlease go to Settings->Receipts and set receipt type."));
+		return;
+	}
 	w->setPersistentSettingsId("cardPreview");
 	w->setWindowTitle(tr("Receipt"));
 	w->setReport(findReportFile(settings.receiptPath()));
 	QVariantMap dt = receiptTablesData(card_id);
 	for(auto key : dt.keys())
 		w->setTableData(key, dt.value(key));
-	qff::MainWindow *fwk = qff::MainWindow::frameWork();
+	auto fwk = qff::MainWindow::frameWork();
 	qf::qmlwidgets::dialogs::Dialog dlg(fwk);
 	dlg.setCentralWidget(w);
 	dlg.exec();
@@ -485,6 +491,11 @@ bool ReceiptsPlugin::printReceipt(int card_id)
 	QF_TIME_SCOPE("ReceiptsPlugin::printReceipt()");
 	try {
 		ReceiptsSettings settings;
+		if (settings.receiptPath().isEmpty()) {
+			auto fwk = qff::MainWindow::frameWork();
+			QMessageBox::warning(fwk,tr("Warning"),tr("Receipt report type is not defined.\nPlease go to Settings->Receipts and set receipt type."));
+			return false;
+		}
 		QVariantMap dt = receiptTablesData(card_id);
 		return receiptsPrinter()->printReceipt(settings.receiptPath(), dt, card_id);
 	}

--- a/quickevent/app/quickevent/plugins/Relays/qml/reports/startList_classes_condensed.qml
+++ b/quickevent/app/quickevent/plugins/Relays/qml/reports/startList_classes_condensed.qml
@@ -1,0 +1,134 @@
+import qf.qmlreports 1.0
+import shared.qml.reports 1.0
+
+Report {
+	id: root
+	objectName: "root"
+
+	property string reportTitle: qsTr("Start list by classes")
+	property bool isBreakAfterEachClass: false
+	property bool isColumnBreak: false
+	property bool isPrintStartNumbers: false
+	property var options
+
+	//debugLevel: 1
+	styleSheet: StyleSheet {
+		objectName: "portraitStyleSheet"
+		basedOn: ReportStyleCommon { id: myStyle }
+		colors: [
+		]
+		pens: [
+			Pen {name: "red1dot"
+				basedOn: "black1"
+				color: Color {def:"red"}
+				style: Pen.DotLine
+			},
+			Pen {
+				id: pen_black1
+				basedOn: "black1"
+			}
+		]
+	}
+	textStyle: myStyle.textStyleDefault
+
+	width: root.options.pageWidth? root.options.pageWidth: 210
+	height: root.options.pageHeight? root.options.pageHeight: 297
+	hinset: root.options.horizontalMargin? root.options.horizontalMargin: 10
+	vinset: root.options.verticalMargin? root.options.verticalMargin: 5
+	Frame {
+		width: "%"
+		height: "%"
+		layout: Frame.LayoutStacked
+		QuickEventHeaderFooter {
+			reportTitle: root.reportTitle
+		}
+		Frame {
+			width: "%"
+			height: "%"
+			columns: root.options.columns
+			vinset: 10
+			Band {
+				id: band
+				objectName: "band"
+				width: "%"
+				height: "%"
+				QuickEventReportHeader {
+					dataBand: band
+					reportTitle: root.reportTitle
+				}
+				Space { height: 5 }
+				Detail {
+					id: detail
+					objectName: "detail"
+					width: "%"
+					layout: Frame.LayoutVertical
+					function dataFn(field_name) {return function() {return rowData(field_name);}}
+					Break {
+						breakType: root.isColumnBreak? Break.Column: Break.Page;
+						visible: root.isBreakAfterEachClass;
+						skipFirst: true
+					}
+					Space {height: 2}
+					Frame {
+						width: "%"
+						vinset: 1
+						layout: Frame.LayoutHorizontal
+						fill: Brush {color: Color {def: "khaki"} }
+						Cell {
+							width: "2"
+						}
+						Cell {
+							width: "%"
+							textFn: detail.dataFn("classes.name");
+							textStyle: myStyle.textStyleBold
+						}
+					}
+					Band {
+						id: relayBand
+						width: "%"
+						htmlExportAsTable: true
+						Detail {
+							id: relayDetail
+							width: "%"
+							layout: Frame.LayoutVertical
+							function dataFn(field_name) {return function() {return rowData(field_name);}}
+							Frame {
+								width: "%"
+								layout: Frame.LayoutHorizontal
+								Cell {
+									width: "10"
+									halign: Frame.AlignRight
+									textFn: function() {
+										return relayDetail.dataFn("relays.number")();
+									}
+								}
+								Cell {
+									width: "5"
+								}
+								Cell {
+									width: "15"
+									halign: Frame.AlignLeft
+									textFn: function() {
+										return relayDetail.dataFn("relayName")();
+									}
+								}
+								Cell {
+									width: "5"
+								}
+								Cell {
+									width: "%"
+									halign: Frame.AlignLeft
+									textFn: function() {
+										return relayDetail.dataFn("clubs.name")();
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+

--- a/quickevent/app/quickevent/plugins/Relays/qml/reports/startList_clubs_condensed.qml
+++ b/quickevent/app/quickevent/plugins/Relays/qml/reports/startList_clubs_condensed.qml
@@ -1,0 +1,137 @@
+import qf.qmlreports 1.0
+import shared.qml.reports 1.0
+
+Report {
+	id: root
+	objectName: "root"
+
+	property string reportTitle: qsTr("Start list by clubs")
+	property bool isBreakAfterEachClass: false
+	property bool isColumnBreak: false
+	property bool isPrintStartNumbers: false
+	property var options
+
+	//debugLevel: 1
+	styleSheet: StyleSheet {
+		objectName: "portraitStyleSheet"
+		basedOn: ReportStyleCommon { id: myStyle }
+		colors: [
+		]
+		pens: [
+			Pen {name: "red1dot"
+				basedOn: "black1"
+				color: Color {def:"red"}
+				style: Pen.DotLine
+			},
+			Pen {
+				id: pen_black1
+				basedOn: "black1"
+			}
+		]
+	}
+	textStyle: myStyle.textStyleDefault
+
+	width: root.options.pageWidth? root.options.pageWidth: 210
+	height: root.options.pageHeight? root.options.pageHeight: 297
+	hinset: root.options.horizontalMargin? root.options.horizontalMargin: 10
+	vinset: root.options.verticalMargin? root.options.verticalMargin: 5
+	Frame {
+		width: "%"
+		height: "%"
+		layout: Frame.LayoutStacked
+		QuickEventHeaderFooter {
+			reportTitle: root.reportTitle
+		}
+		Frame {
+			width: "%"
+			height: "%"
+			columns: root.options.columns
+			vinset: 10
+			Band {
+				id: band
+				objectName: "band"
+				width: "%"
+				height: "%"
+				QuickEventReportHeader {
+					dataBand: band
+					reportTitle: root.reportTitle
+				}
+				Space { height: 5 }
+				Detail {
+					id: detail
+					objectName: "detail"
+					width: "%"
+					layout: Frame.LayoutVertical
+					function dataFn(field_name) {return function() {return rowData(field_name);}}
+					Break {
+						breakType: root.isColumnBreak? Break.Column: Break.Page;
+						visible: root.isBreakAfterEachClass;
+						skipFirst: true
+					}
+					Space {height: 2}
+					Frame {
+						width: "%"
+						vinset: 1
+						layout: Frame.LayoutHorizontal
+						fill: Brush {color: Color {def: "khaki"} }
+						textStyle: myStyle.textStyleBold
+						Cell {
+							width: "2"
+						}
+						Cell {
+							textFn: detail.dataFn("club");
+						}
+						Cell {
+							width: "%"
+							textFn: detail.dataFn("name");
+						}
+					}
+					Band {
+						id: relayBand
+						width: "%"
+						htmlExportAsTable: true
+						Detail {
+							id: relayDetail
+							width: "%"
+							layout: Frame.LayoutVertical
+							function dataFn(field_name) {return function() {return rowData(field_name);}}
+							Frame {
+								width: "%"
+								layout: Frame.LayoutHorizontal
+								Cell {
+									width: "10"
+									halign: Frame.AlignRight
+									textFn: function() {
+										return relayDetail.dataFn("relays.number")();
+									}
+								}
+								Cell {
+									width: "5"
+								}
+								Cell {
+									width: "10"
+									halign: Frame.AlignHCenter
+									textFn: function() {
+										return relayDetail.dataFn("classes.name")();
+									}
+								}
+								Cell {
+									width: "5"
+								}
+								Cell {
+									width: "%"
+									halign: Frame.AlignLeft
+									textFn: function() {
+										return relayDetail.dataFn("relayName")();
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+

--- a/quickevent/app/quickevent/plugins/Relays/src/relaysplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/relaysplugin.cpp
@@ -242,7 +242,7 @@ qf::core::utils::TreeTable RelaysPlugin::nLegsClassResultsTable(int class_id, in
 				.from("relays")
 				.join("relays.club", "clubs.abbr")
 				.where("relays.classId=" QF_IARG(class_id))
-				.where("relays.isRunning");
+				.where("relays.isRelRunning");
 		q.execThrow(qb.toString());
 		while(q.next()) {
 			Relay r;
@@ -497,7 +497,7 @@ QVariant RelaysPlugin::startListByClassesTableData(const QString &class_filter, 
 				.where("relays.classId={{class_id}}")
 				.orderBy("relays.number, relayName");
 		if (!with_vacants)
-			qb.where("relays.isRunning");
+			qb.where("relays.isRelRunning");
 
 		model.setQueryBuilder(qb, true);
 	}

--- a/quickevent/app/quickevent/plugins/Relays/src/relaysplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/relaysplugin.cpp
@@ -242,7 +242,7 @@ qf::core::utils::TreeTable RelaysPlugin::nLegsClassResultsTable(int class_id, in
 				.from("relays")
 				.join("relays.club", "clubs.abbr")
 				.where("relays.classId=" QF_IARG(class_id))
-				.where("relays.isRelRunning");
+				.where("relays.isRunning");
 		q.execThrow(qb.toString());
 		while(q.next()) {
 			Relay r;
@@ -497,7 +497,7 @@ QVariant RelaysPlugin::startListByClassesTableData(const QString &class_filter, 
 				.where("relays.classId={{class_id}}")
 				.orderBy("relays.number, relayName");
 		if (!with_vacants)
-			qb.where("relays.isRelRunning");
+			qb.where("relays.isRunning");
 
 		model.setQueryBuilder(qb, true);
 	}

--- a/quickevent/app/quickevent/plugins/Relays/src/relaysplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/relaysplugin.cpp
@@ -241,7 +241,8 @@ qf::core::utils::TreeTable RelaysPlugin::nLegsClassResultsTable(int class_id, in
 				.select("COALESCE(relays.club, '') || ' ' || COALESCE(relays.name, '') AS relayName")
 				.from("relays")
 				.join("relays.club", "clubs.abbr")
-				.where("relays.classId=" QF_IARG(class_id));
+				.where("relays.classId=" QF_IARG(class_id))
+				.where("relays.isRunning");
 		q.execThrow(qb.toString());
 		while(q.next()) {
 			Relay r;
@@ -466,7 +467,7 @@ qf::core::utils::TreeTable RelaysPlugin::nLegsClassResultsTable(int class_id, in
 	return tt;
 }
 
-QVariant RelaysPlugin::startListByClassesTableData(const QString &class_filter)
+QVariant RelaysPlugin::startListByClassesTableData(const QString &class_filter, bool with_vacants)
 {
 	qfLogFuncFrame() << class_filter;
 	qf::core::model::SqlTableModel model;
@@ -495,6 +496,9 @@ QVariant RelaysPlugin::startListByClassesTableData(const QString &class_filter)
 				.join("relays.club", "clubs.abbr")
 				.where("relays.classId={{class_id}}")
 				.orderBy("relays.number, relayName");
+		if (!with_vacants)
+			qb.where("relays.isRunning");
+
 		model.setQueryBuilder(qb, true);
 	}
 	{
@@ -828,7 +832,7 @@ QString RelaysPlugin::startListIofXml30()
 {
 	QDateTime start00 = getPlugin<EventPlugin>()->stageStartDateTime(1);
 	qfDebug() << "creating table";
-	qf::core::utils::TreeTable tt_classes = startListByClassesTableData(QString());
+	qf::core::utils::TreeTable tt_classes = startListByClassesTableData(QString(),false);
 	QVariantList start_list{
 		"StartList",
 		QVariantMap{

--- a/quickevent/app/quickevent/plugins/Relays/src/relaysplugin.h
+++ b/quickevent/app/quickevent/plugins/Relays/src/relaysplugin.h
@@ -46,7 +46,7 @@ public:
 	qf::core::utils::TreeTable nLegsClassResultsTable(int class_id, int leg_count, int places, bool exclude_not_finish);
 	QString startListIofXml30();
 	QString resultsIofXml30();
-	QVariant startListByClassesTableData(const QString &class_filter);
+	QVariant startListByClassesTableData(const QString &class_filter, bool with_vacants);
 private:
 	Q_SLOT void onInstalled();
 	void onDbEventNotify(const QString &domain, int connection_id, const QVariant &data);

--- a/quickevent/app/quickevent/plugins/Relays/src/relayswidget.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/relayswidget.cpp
@@ -723,7 +723,7 @@ void RelaysWidget::relays_addVacants()
 			cnt = QInputDialog::getInt(fwk, tr("Enter number of new vacants"), QString(tr("Vacants count for class %1 :")).arg(key), cnt, 0, 999, 1, &ok);
 			if(!ok) break;
 			if (cnt > 0) {
-				qfInfo() << "Add" << cnt << "new vacants for:" << key;
+				qfDebug() << "Add" << cnt << "new vacants for:" << key;
 				for (int i = 0; i < cnt; i++) {
 					q.exec("INSERT INTO relays (club, name, classid, isRelRunning) VALUES ('"+vacant+"', 0, "
 						+ QString::number(value) + ", false) ", qf::core::Exception::Throw);
@@ -732,7 +732,7 @@ void RelaysWidget::relays_addVacants()
 			}
 		}
 		if (created > 0) {
-			qfInfo() << "Created"<< created << "new vacants.";
+			qfDebug() << "Created"<< created << "new vacants.";
 			reload();
 		}
 	}

--- a/quickevent/app/quickevent/plugins/Relays/src/relayswidget.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/relayswidget.cpp
@@ -363,6 +363,8 @@ QVariant RelaysWidget::startListByClubsTableData(bool with_vacants)
 				.groupBy("club")
 				.orderBy("club")
 				.as("relay_clubs");
+		if (!with_vacants)
+			qb1.where("relays.isRelRunning");
 		qf::core::sql::QueryBuilder qb;
 		qb.select2("relay_clubs", "club")
 				.select2("clubs", "name")
@@ -454,6 +456,7 @@ void RelaysWidget::print_start_list_clubs()
 	dlg.setPersistentSettingsId("relaysStartReportOptions");
 	dlg.loadPersistentSettings();
 	dlg.setStartListForRelays();
+	dlg.setRelayOptionsVisible(true);
 	dlg.setClassFilterVisible(false);
 	if(!dlg.exec())
 		return;

--- a/quickevent/app/quickevent/plugins/Relays/src/relayswidget.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/relayswidget.cpp
@@ -90,7 +90,7 @@ RelaysWidget::RelaysWidget(QWidget *parent) :
 	m->setColumn(col_relays_name, CD("name", tr("Name")));
 	m->setColumn(col_relays_number, CD("number", tr("Number")));
 	m->setColumn(col_relays_note, CD("note", tr("Note")));
-	m->setColumn(col_relays_isrunning, CD("isrunning", tr("Is Running")));
+	m->setColumn(col_relays_isrunning, CD("isRelRunning", tr("Is Running")));
 	ui->tblRelays->setTableModel(m);
 	m_tblModel = m;
 
@@ -386,7 +386,7 @@ QVariant RelaysWidget::startListByClubsTableData(bool with_vacants)
 				.where("relays.club='{{club}}'")
 				.orderBy("classes.name, relayName");
 		if (!with_vacants)
-			qb.where("relays.isRunning");
+			qb.where("relays.isRelRunning");
 		model.setQueryBuilder(qb, true);
 	}
 	{
@@ -722,7 +722,7 @@ void RelaysWidget::relays_addVacants()
 			if (cnt > 0) {
 				qfInfo() << "Add" << cnt << "new vacants for:" << key;
 				for (int i = 0; i < cnt; i++) {
-					q.exec("INSERT INTO relays (club, name, classid, isrunning) VALUES ('"+vacant+"', 0, "
+					q.exec("INSERT INTO relays (club, name, classid, isRelRunning) VALUES ('"+vacant+"', 0, "
 						+ QString::number(value) + ", false) ", qf::core::Exception::Throw);
 				}
 				created+= cnt;

--- a/quickevent/app/quickevent/plugins/Relays/src/relayswidget.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/relayswidget.cpp
@@ -90,7 +90,7 @@ RelaysWidget::RelaysWidget(QWidget *parent) :
 	m->setColumn(col_relays_name, CD("name", tr("Name")));
 	m->setColumn(col_relays_number, CD("number", tr("Number")));
 	m->setColumn(col_relays_note, CD("note", tr("Note")));
-	m->setColumn(col_relays_isrunning, CD("isRelRunning", tr("Is Running")));
+	m->setColumn(col_relays_isrunning, CD("isrunning", tr("Is Running")));
 	ui->tblRelays->setTableModel(m);
 	m_tblModel = m;
 
@@ -388,7 +388,7 @@ QVariant RelaysWidget::startListByClubsTableData(bool with_vacants)
 				.where("relays.club='{{club}}'")
 				.orderBy("classes.name, relayName");
 		if (!with_vacants)
-			qb.where("relays.isRelRunning");
+			qb.where("relays.isRunning");
 		model.setQueryBuilder(qb, true);
 	}
 	{
@@ -725,7 +725,7 @@ void RelaysWidget::relays_addVacants()
 			if (cnt > 0) {
 				qfDebug() << "Add" << cnt << "new vacants for:" << key;
 				for (int i = 0; i < cnt; i++) {
-					q.exec("INSERT INTO relays (club, name, classid, isRelRunning) VALUES ('"+vacant+"', 0, "
+					q.exec("INSERT INTO relays (club, name, classid, isrunning) VALUES ('"+vacant+"', 0, "
 						+ QString::number(value) + ", false) ", qf::core::Exception::Throw);
 				}
 				created+= cnt;

--- a/quickevent/app/quickevent/plugins/Relays/src/relayswidget.h
+++ b/quickevent/app/quickevent/plugins/Relays/src/relayswidget.h
@@ -40,10 +40,11 @@ private:
 
 	//void onDbEventNotify(const QString &domain, int connection_id, const QVariant &data);
 
-	QVariant startListByClubsTableData();
+	QVariant startListByClubsTableData(bool with_vacants);
 
 	void relays_assignNumbers();
 	void relays_importBibs();
+	void relays_addVacants();
 
 	void print_start_list_classes();
 	void print_start_list_clubs();

--- a/quickevent/app/quickevent/plugins/Relays/src/relaywidget.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/relaywidget.cpp
@@ -217,6 +217,9 @@ void RelayWidget::addLeg()
 void RelayWidget::removeLeg()
 {
 	qfLogFuncFrame();
+	QModelIndex curr_ix = ui->tblLegs->currentIndex();
+	if(!curr_ix.isValid())
+		return;
 	qf::core::utils::TableRow row = ui->tblLegs->selectedRow();
 	int run_id = row.value("runs.id").toInt();
 	qfDebug() << "run id:" << run_id;

--- a/quickevent/app/quickevent/plugins/Relays/src/relaywidget.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/relaywidget.cpp
@@ -30,9 +30,6 @@
 #include <QPushButton>
 
 namespace qfd = qf::qmlwidgets::dialogs;
-namespace qfw = qf::qmlwidgets;
-namespace qfc = qf::core;
-namespace qfs = qf::core::sql;
 
 namespace {
 

--- a/quickevent/app/quickevent/plugins/Relays/src/relaywidget.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/relaywidget.cpp
@@ -127,7 +127,7 @@ RelayWidget:: RelayWidget(QWidget *parent) :
 
 bool  RelayWidget::loadLegsTable()
 {
-	qf::core::model::DataDocument *doc = dataController()->document();
+	auto doc = dataController()->document();
 	qf::core::sql::QueryBuilder qb;
 	qb.select2("runs", "*")
 			.select2("competitors", "registration")
@@ -178,7 +178,7 @@ void RelayWidget::checkLegsStartTimes()
 		if(leg == 1 && m_legsModel->value(i, LegsModel::col_runs_startTimeMs).isNull()) {
 			/// assign class start time
 			int run_id = m_legsModel->tableRow(i).value(QStringLiteral("runs.id")).toInt();
-			qf::core::model::DataDocument *doc = dataDocument();
+			auto doc = dataDocument();
 			int class_id = doc->value(QStringLiteral("relays.classId")).toInt();
 			qf::core::sql::Query q;
 			q.execThrow("SELECT startTimeMin FROM classdefs WHERE classId=" QF_IARG(class_id));
@@ -196,7 +196,7 @@ void RelayWidget::addLeg()
 	if(!saveData())
 		return;
 	auto doc = qobject_cast<Relays:: RelayDocument*>(dataController()->document());
-	auto *w = new AddLegDialogWidget();
+	auto w = new AddLegDialogWidget();
 	w->setClassId(doc->value(QStringLiteral("classId")).toInt());
 	w->setRelayId(doc->dataId().toInt());
 	w->setWindowTitle(tr("Add leg"));
@@ -217,10 +217,10 @@ void RelayWidget::addLeg()
 void RelayWidget::removeLeg()
 {
 	qfLogFuncFrame();
-	QModelIndex curr_ix = ui->tblLegs->currentIndex();
+	auto curr_ix = ui->tblLegs->currentIndex();
 	if(!curr_ix.isValid())
 		return;
-	qf::core::utils::TableRow row = ui->tblLegs->selectedRow();
+	auto row = ui->tblLegs->selectedRow();
 	int run_id = row.value("runs.id").toInt();
 	int comp_id = row.value("runs.competitorid").toInt();
 	qfDebug() << "run id:" << run_id << "comp id:" << comp_id;
@@ -234,10 +234,10 @@ void RelayWidget::removeLeg()
 
 void RelayWidget::moveLegUp()
 {
-	QModelIndex curr_ix = ui->tblLegs->currentIndex();
+	auto curr_ix = ui->tblLegs->currentIndex();
 	if(!curr_ix.isValid())
 		return;
-	qf::core::utils::TableRow row = ui->tblLegs->selectedRow();
+	auto row = ui->tblLegs->selectedRow();
 	int leg = row.value("runs.leg").toInt();
 	if(leg <= 1)
 		return;
@@ -279,17 +279,17 @@ void RelayWidget::moveLegUp()
 
 void RelayWidget::moveLegDown()
 {
-	QModelIndex curr_ix = ui->tblLegs->currentIndex();
+	auto curr_ix = ui->tblLegs->currentIndex();
 	if(!curr_ix.isValid())
 		return;
-	qf::core::model::TableModel *m = ui->tblLegs->tableModel();
+	auto m = ui->tblLegs->tableModel();
 	int max_leg = 0;
 	for (int i = 0; i < m->rowCount(); ++i) {
 		int l = m->value(i, "runs.leg").toInt();
 		if(l > max_leg)
 			max_leg = l;
 	}
-	qf::core::utils::TableRow row = ui->tblLegs->selectedRow();
+	auto row = ui->tblLegs->selectedRow();
 	int leg = row.value("runs.leg").toInt();
 	if(leg >= max_leg)
 		return;

--- a/quickevent/app/quickevent/plugins/Relays/src/relaywidget.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/relaywidget.cpp
@@ -222,10 +222,12 @@ void RelayWidget::removeLeg()
 		return;
 	qf::core::utils::TableRow row = ui->tblLegs->selectedRow();
 	int run_id = row.value("runs.id").toInt();
-	qfDebug() << "run id:" << run_id;
-	if(run_id > 0) {
+	int comp_id = row.value("runs.competitorid").toInt();
+	qfDebug() << "run id:" << run_id << "comp id:" << comp_id;
+	if(run_id > 0 && comp_id > 0) {
 		qf::core::sql::Query q;
 		q.exec("DELETE FROM runs WHERE id=" + QString::number(run_id), qf::core::Exception::Throw);
+		q.exec("DELETE FROM competitors WHERE id=" + QString::number(comp_id), qf::core::Exception::Throw);
 		loadLegsTable();
 	}
 }

--- a/quickevent/app/quickevent/plugins/Relays/src/relaywidget.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/relaywidget.cpp
@@ -150,7 +150,7 @@ bool  RelayWidget::load(const QVariant &id, int mode)
 
 bool  RelayWidget::saveData()
 {
-	Relays::RelayDocument*doc = qobject_cast<Relays:: RelayDocument*>(dataController()->document());
+	auto doc = qobject_cast<Relays:: RelayDocument*>(dataController()->document());
 	if(doc->value(QStringLiteral("classId")).toInt() == 0) {
 		qf::qmlwidgets::dialogs::MessageBox::showWarning(this, tr("Class should be entered."));
 		return false;
@@ -195,7 +195,7 @@ void RelayWidget::addLeg()
 {
 	if(!saveData())
 		return;
-	Relays::RelayDocument*doc = qobject_cast<Relays:: RelayDocument*>(dataController()->document());
+	auto doc = qobject_cast<Relays:: RelayDocument*>(dataController()->document());
 	auto *w = new AddLegDialogWidget();
 	w->setClassId(doc->value(QStringLiteral("classId")).toInt());
 	w->setRelayId(doc->dataId().toInt());
@@ -241,7 +241,7 @@ void RelayWidget::moveLegUp()
 	int leg = row.value("runs.leg").toInt();
 	if(leg <= 1)
 		return;
-	Relays::RelayDocument*doc = qobject_cast<Relays:: RelayDocument*>(dataController()->document());
+	auto doc = qobject_cast<Relays:: RelayDocument*>(dataController()->document());
 	int relay_id = doc->dataId().toInt();
 	int run_id = row.value("runs.id").toInt();
 	QVariant run_stime = row.value("startTimeMs");
@@ -293,7 +293,7 @@ void RelayWidget::moveLegDown()
 	int leg = row.value("runs.leg").toInt();
 	if(leg >= max_leg)
 		return;
-	Relays::RelayDocument*doc = qobject_cast<Relays:: RelayDocument*>(dataController()->document());
+	auto doc = qobject_cast<Relays:: RelayDocument*>(dataController()->document());
 	int relay_id = doc->dataId().toInt();
 	int run_id = row.value("runs.id").toInt();
 	QVariant run_stime = row.value("startTimeMs");

--- a/quickevent/app/quickevent/plugins/Runs/src/findrunneredit.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/findrunneredit.cpp
@@ -106,7 +106,7 @@ QVariantMap FindRunnerEdit::selectedRunner() const
 
 void FindRunnerEdit::onCompleterActivated(const QModelIndex &index)
 {
-	qfLogFuncFrame() << index << index.data();
+	qfLogFuncFrame();// << index << index.data();
 	auto *proxy_model = qobject_cast<QAbstractProxyModel*>(completer()->completionModel());
 	QF_ASSERT(proxy_model != nullptr, "Bat proxy model!", return);
 	QModelIndex ix = proxy_model->mapToSource(index);

--- a/quickevent/app/quickevent/plugins/Runs/src/findrunneredit.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/findrunneredit.cpp
@@ -68,7 +68,7 @@ QVariant FindRunnersModel::data(const QModelIndex &index, int role) const
 					+ SI + table_row.value(col_siid).toString() + ' '
 					+ BIB + table_row.value(col_bib).toString();
 		}
-		else if(role == Qt::EditRole) {
+		if(role == Qt::EditRole) {
 			return table_row.value(col_class_name).toString() + ' '
 					+ table_row.value(col_searchkey).toString() + ' '
 					+ table_row.value(col_registration).toString() + ' '

--- a/quickevent/app/quickevent/quickevent-cs_CZ.ts
+++ b/quickevent/app/quickevent/quickevent-cs_CZ.ts
@@ -1097,20 +1097,34 @@ Zvažte nastavení intervalu pro všechny kategorie.</translation>
         <translation>Chcete odstranit všechny definice tratí pro etapu %1?</translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="457"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="527"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="634"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="705"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="458"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="639"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="713"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="458"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="639"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="713"/>
+        <source>Import does not yet support relays.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="462"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="532"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="644"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="720"/>
         <source>Open file</source>
         <translation>Otevřít soubor</translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="634"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="644"/>
         <source>XML files (*.xml);; All files (*)</source>
         <translation>XML soubory (*.xml);; Všechny soubory (*)</translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="802"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="817"/>
         <source>Class name &apos;%1&apos; seems to be combined, separate it to more classes?</source>
         <translation>Název kategorie &apos;%1&apos; je pravděpodobně složený. Mám jej rozdělit na více kategorií?</translation>
     </message>
@@ -1806,8 +1820,9 @@ Zvažte nastavení intervalu pro všechny kategorie.</translation>
     </message>
     <message>
         <location filename="plugins/Core/src/coreplugin.cpp" line="155"/>
-        <source>&amp;About Quick event</source>
-        <translation>O &amp;aplikaci Quick Event</translation>
+        <source>&amp;About Quick Event</source>
+        <oldsource>&amp;About Quick event</oldsource>
+        <translation type="unfinished">O &amp;aplikaci Quick Event</translation>
     </message>
     <message>
         <location filename="plugins/Core/src/coreplugin.cpp" line="160"/>
@@ -1815,17 +1830,21 @@ Zvažte nastavení intervalu pro všechny kategorie.</translation>
         <translation>O knihovně &amp;Qt</translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="203"/>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="209"/>
         <source>About Quick Event</source>
         <translation>O aplikaci Quick Event</translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="204"/>
-        <source>The &lt;b&gt;Quick Event&lt;/b&gt; is an application which helps you to organize the orienteering events.&lt;br/&gt;&lt;br/&gt;version: %1&lt;br/&gt;min. db version: %2&lt;br/&gt;build: %3 %4&lt;br/&gt;SSL build: %5&lt;br/&gt;SSL run: %6</source>
-        <translation>&lt;b&gt;Quick Event&lt;/b&gt; je aplikace na pořádání závodů v orientačním běhu.&lt;br/&gt;&lt;br/&gt;Verze aplikace: %1&lt;br/&gt;Minimální verze databáze: %2&lt;br/&gt;Datum a čas sestavení: %3 %4&lt;br/&gt;Verze SSL knihovny při sestavení: %5&lt;br/&gt;Verze aktuálně využívané SSL knihovny: %6</translation>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="210"/>
+        <source>The &lt;b&gt;Quick Event&lt;/b&gt; is an application which helps you to organize the orienteering events.&lt;br/&gt;&lt;br/&gt;version: %1&lt;br/&gt;commit: %7&lt;br/&gt;min. db version: %2&lt;br/&gt;build: %3 %4&lt;br/&gt;SSL build: %5&lt;br/&gt;SSL run: %6</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="223"/>
+        <source>The &lt;b&gt;Quick Event&lt;/b&gt; is an application which helps you to organize the orienteering events.&lt;br/&gt;&lt;br/&gt;version: %1&lt;br/&gt;min. db version: %2&lt;br/&gt;build: %3 %4&lt;br/&gt;SSL build: %5&lt;br/&gt;SSL run: %6</source>
+        <translation type="vanished">&lt;b&gt;Quick Event&lt;/b&gt; je aplikace na pořádání závodů v orientačním běhu.&lt;br/&gt;&lt;br/&gt;Verze aplikace: %1&lt;br/&gt;Minimální verze databáze: %2&lt;br/&gt;Datum a čas sestavení: %3 %4&lt;br/&gt;Verze SSL knihovny při sestavení: %5&lt;br/&gt;Verze aktuálně využívané SSL knihovny: %6</translation>
+    </message>
+    <message>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="231"/>
         <source>About Qt</source>
         <translation>O knihovně Qt</translation>
     </message>
@@ -1966,7 +1985,7 @@ Zvažte nastavení intervalu pro všechny kategorie.</translation>
 <context>
     <name>DbSchema</name>
     <message>
-        <location filename="plugins/Event/qml/DbSchema.qml" line="507"/>
+        <location filename="plugins/Event/qml/DbSchema.qml" line="511"/>
         <source>Data version</source>
         <translation>Verze dat</translation>
     </message>
@@ -3290,71 +3309,71 @@ zdroj - ORIS-&gt;Závod-&gt;Informace-&gt;Bezpečnostní klíč závodu</transla
 <context>
     <name>LegsModel</name>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="65"/>
         <source>Leg</source>
         <comment>relays.leg</comment>
         <translation>Úsek</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="65"/>
         <source>Leg</source>
         <translation>Úsek</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="69"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="66"/>
         <source>Name</source>
         <translation>Jméno</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="70"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="67"/>
         <source>Reg</source>
         <translation>Reg. č.</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
         <source>SI</source>
         <translation>SI</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="69"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="70"/>
         <source>Time</source>
         <translation>Čas</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="74"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
         <source>NC</source>
         <comment>runs.notCompeting</comment>
         <translation>MS</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="74"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
         <source>Not competing</source>
         <translation>Mimo soutěž</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="75"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
         <source>D</source>
         <comment>runs.disqualified</comment>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="75"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
         <source>Disqualified</source>
         <translation>Diskvalifikace</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="76"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
         <source>E</source>
         <comment>runs.misPunch</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="76"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
         <source>Card mispunch</source>
         <translation>Chybné ražení</translation>
     </message>
@@ -3647,107 +3666,107 @@ zdroj - ORIS-&gt;Závod-&gt;Informace-&gt;Bezpečnostní klíč závodu</transla
 <context>
     <name>OrisImporter</name>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="168"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="169"/>
         <source>Cannot find Oris import ID.</source>
         <translation>Nelze najít ORIS ID pro provedení synchronizace.</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="720"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="731"/>
         <source>New entries</source>
         <translation>Nové přihlášky</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="721"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="732"/>
         <source>Edited entries</source>
         <translation>Upravené přihlášky</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="722"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="733"/>
         <source>Deleted entries</source>
         <translation>Smazané přihlášky</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="725"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="736"/>
         <source>Oris import report</source>
         <translation>Zpráva o importu z ORISu</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="735"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="746"/>
         <source>Save without drops</source>
         <translation>Uložit bez smazaných</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="742"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="753"/>
         <source>Export</source>
         <translation>Exportovat</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="744"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="755"/>
         <source>Export as ...</source>
         <translation>Exportovat jako ...</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="744"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="755"/>
         <source>HTML files *.html (*.html)</source>
         <translation>soubory HTML *.html(*.html)</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="751"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="762"/>
         <source>Cannot open file &apos;%1&apos; for writing.</source>
         <translation>Soubor &apos;%1&apos; nelze otevřít pro zápis.</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="833"/>
         <source>Importing registrations</source>
         <translation>Importuji registrace</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="879"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="890"/>
         <source>Importing clubs</source>
         <translation>Importuji kluby</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="938"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="949"/>
         <source>Warning</source>
         <translation>Upozornění</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="938"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="949"/>
         <source>For import one-time clubs, you need to fill ORIS Event Key in File-&gt;Event-&gt;Edit event</source>
         <translation>Pro import jednorázových klubů je potřeba mít vyplněn ORISový bezpečnostní klíč závodu v Soubor-&gt;Závod-&gt;Upravit závod</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="963"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="988"/>
         <source>Information</source>
         <translation>Informace</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="963"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="988"/>
         <source>No missing one-time clubs found.</source>
         <translation>Nenalezen žádný chybějící jednorázový klub.</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="969"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="994"/>
         <source>Importing one-time clubs</source>
         <translation>Importuji jednorázové kluby</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="127"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="128"/>
         <source>JSON document parse error: %1 at: %2 near: %3</source>
         <translation>Chyba při analýze JSON dokumentu: %1 na: %2 poblíž: %3</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="341"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="342"/>
         <source>Import finished successfully.</source>
         <translation>Import byl úspěšně dokončen.</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="811"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
         <source>Import ORIS Registrations</source>
         <translation>Importovat registrace z ORISu</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="811"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
         <source>Year of registration:</source>
         <translation>Registrace z roku:</translation>
     </message>
@@ -4082,7 +4101,7 @@ zdroj - ORIS-&gt;Závod-&gt;Informace-&gt;Bezpečnostní klíč závodu</transla
     </message>
     <message>
         <location filename="plugins/Relays/src/relaywidget.ui" line="35"/>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="99"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="96"/>
         <source>Relay</source>
         <translation>Štafeta</translation>
     </message>
@@ -4171,17 +4190,17 @@ zdroj - ORIS-&gt;Závod-&gt;Informace-&gt;Bezpečnostní klíč závodu</transla
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="158"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="155"/>
         <source>Class should be entered.</source>
         <translation>Není zadána kategorie.</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="162"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="159"/>
         <source>Relay ID invalid.</source>
         <translation>Neplatné ID štafety.</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="205"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="202"/>
         <source>Add leg</source>
         <translation>Přidat úsek</translation>
     </message>
@@ -4200,12 +4219,12 @@ zdroj - ORIS-&gt;Závod-&gt;Informace-&gt;Bezpečnostní klíč závodu</transla
         <translation>&amp;Štafety</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaysplugin.cpp" line="823"/>
+        <location filename="plugins/Relays/src/relaysplugin.cpp" line="827"/>
         <source>Relays IOF-XML 3.0 results</source>
         <translation>Výsledky štafet ve formátu IOF XML 3.0</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaysplugin.cpp" line="964"/>
+        <location filename="plugins/Relays/src/relaysplugin.cpp" line="968"/>
         <source>Relays IOF-XML 3.0 startlist</source>
         <translation>Startovka štafet ve formátu IOF XML 3.0</translation>
     </message>
@@ -4218,230 +4237,255 @@ zdroj - ORIS-&gt;Závod-&gt;Informace-&gt;Bezpečnostní klíč závodu</transla
         <translation>Formulář</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="87"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="88"/>
         <source>Class</source>
         <translation>Kategorie</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="88"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="89"/>
         <source>Club</source>
         <translation>Klub</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="89"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="90"/>
         <source>Name</source>
         <translation>Jméno</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="90"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="91"/>
         <source>Number</source>
         <translation>Číslo</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="91"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="92"/>
         <source>Note</source>
         <translation>Poznámka</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="117"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="93"/>
+        <source>Is Running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="119"/>
         <source>&amp;Class </source>
         <translation>&amp;Kategorie </translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="144"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="146"/>
         <source>&amp;Relays</source>
         <translation>&amp;Štafety</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="146"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="148"/>
         <source>&amp;Assign numbers</source>
         <translation>&amp;Přiřadit čísla</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="151"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="153"/>
         <source>&amp;Import bibs from CSV</source>
         <translation>&amp;Importovat startovní čísla z soubrou CSV</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="157"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="158"/>
+        <source>Add new &amp;vacants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="164"/>
         <source>&amp;Print</source>
         <translation>&amp;Tisk</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="159"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="186"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="166"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="193"/>
         <source>&amp;Start list</source>
         <translation>&amp;Startovní listina</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="160"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="167"/>
         <source>&amp;Classes</source>
         <translation>&amp;Kategorie</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="163"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="170"/>
         <source>C&amp;lubs</source>
         <translation>K&amp;luby</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="167"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="192"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="174"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="199"/>
         <source>&amp;Results</source>
         <translation>&amp;Výsledky</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="169"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="176"/>
         <source>&amp;After n legs</source>
         <translation>&amp;Po n úsecích</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="174"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="181"/>
         <source>&amp;Overall</source>
         <oldsource>&amp;Overal</oldsource>
         <translation>&amp;Celkové</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="179"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="186"/>
         <source>Overall condensed</source>
         <translation>Celkové zestručněné</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="185"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="192"/>
         <source>E&amp;xport</source>
         <translation>E&amp;xportovat</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="188"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="194"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="195"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="201"/>
         <source>IOF-XML 3.0</source>
         <translation>IOF XML 3.0</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="213"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="220"/>
         <source>--- all ---</source>
         <translation>-- všechny --</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="242"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="249"/>
         <source>Edit Relay</source>
         <oldsource>Edit  Relay</oldsource>
         <translation>Upravit štafetu</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="245"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="252"/>
         <source>Save and &amp;next</source>
         <translation>Uložit a &amp;další</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="277"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="284"/>
         <source>Really delete all the selected relays? This action cannot be reverted.</source>
         <translation>Opravdu odstranit všechny vybrané štafety? Tuto akci nelze vrátit zpět.</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="290"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="297"/>
         <source>Confirm deletion of %1 relays.</source>
         <translation>Potvrďte smazání %1 štafet.</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="310"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="317"/>
         <source>Dialog</source>
         <translation>Dialog</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="310"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="317"/>
         <source>Assign relay numbers method</source>
         <translation>Způsob přiřazení čísel štafetám</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="311"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="318"/>
         <source>Random number</source>
         <translation>Náhodné číslo</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="311"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="318"/>
         <source>In alphabetical order</source>
         <translation>V abecedním pořadí</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="431"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="445"/>
         <source>Start list by classes</source>
         <translation>Startovní listina po kategoriích</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="450"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="467"/>
         <source>Start list by clubs</source>
         <translation>Startovní listina po klubech</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="478"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="502"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="526"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="495"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="519"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="543"/>
         <source>Results</source>
         <translation>Výsledky</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="536"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="553"/>
         <source>Save as %1</source>
         <translation>Uložit jako %1</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="569"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="586"/>
         <source>Import UTF8 text file with comma separated values with first row as header.&lt;br/&gt;Separator is semicolon(;).&lt;br/&gt;Updates only existing relays (key is Club, Relay Name &amp; Class).</source>
         <translation>Importovat soubor s hodnotami oddělenými čárkou (CSV), včetně záhlaví, v kódování UTF-8.&lt;br/&gt;Oddělovač je středník(;).&lt;br/&gt;Aktualizuje pouze existujiící štafety (klíč je Klub, Název štafety a Kategorie).</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="570"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="587"/>
         <source>Each row should have following columns: &lt;ol&gt;&lt;li&gt;Club abbr &lt;i&gt;- key (part1)&lt;/i&gt;&lt;/li&gt;&lt;li&gt;Relay name &lt;i&gt;- key (part2)&lt;/i&gt;&lt;/li&gt;&lt;li&gt;Start number (Bib)&lt;/li&gt;&lt;li&gt;Class (Optional - if not filed, trying to guess from the starting number)&lt;/li&gt;&lt;/ol&gt;</source>
         <translation>Každý řádek by měl mít následující sloupce:&lt;ol&gt;&lt;li&gt;Zkratka klubu &lt;i&gt;- klíč (část1)&lt;/i&gt;&lt;/li&gt;&lt;li&gt;Název štafety&lt;i&gt; - klíč (část2)&lt;/i&gt;&lt;/li&gt;&lt;li&gt;Startovní číslo&lt;/li&gt;&lt;li&gt;Kategorii (Volitelné - pokud není vyplněno,  zkouší se kategorie odhadnout podle startovního čísla)&lt;/li&gt;&lt;/ol&gt;</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="582"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="599"/>
         <source>Open file</source>
         <translation>Otevřít soubor</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="582"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="599"/>
         <source>CSV files (*.csv *.txt)</source>
         <translation>soubory CSV (*.csv *.txt)</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="598"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="615"/>
         <source>Cannot open file &apos;%1&apos; for reading.</source>
         <translation>Soubor &apos;%1&apos; nelze otevřít pro čtení.</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="617"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="634"/>
         <source>Fields separation error, invalid CSV format, Error reading CSV line: [%1]</source>
         <translation>Chyba při analýze CSV souboru, neplatný formát, chyba při čtení řádky: [%1]</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="627"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="644"/>
         <source>Error reading CSV line: [%1]</source>
         <translation>Chyba při čtení souboru CSV, řádek: [%1]</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="638"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="655"/>
         <source>Cannot guess class name from bib: &apos;%1&apos;</source>
         <translation>Nemohu odhadnout název kategorie podle startovního čísla: &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="643"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="660"/>
         <source>Undefined class name: &apos;%1&apos;</source>
         <translation>Neznámý název kategorie: &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="680"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="697"/>
         <source>Information</source>
         <translation>Informace</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="680"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="697"/>
         <source>Import file finished. Imported %1 of %2 lines
 
 Press refresh button to show imported data.</source>
         <translation>Import souboru hotov. Importováno %1 z %2 řádků
 
 Stskněte tlačítko pro obnovení pro zobrazení importovaných dat.</translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="718"/>
+        <source>vac</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="720"/>
+        <source>Enter number of new vacants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="720"/>
+        <source>Vacants count for class %1 :</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6383,6 +6427,14 @@ Přejete si uložit změny?</translation>
     </message>
 </context>
 <context>
+    <name>startList_classes_condensed</name>
+    <message>
+        <location filename="plugins/Relays/qml/reports/startList_classes_condensed.qml" line="8"/>
+        <source>Start list by classes</source>
+        <translation type="unfinished">Startovní listina po kategoriích</translation>
+    </message>
+</context>
+<context>
     <name>startList_classes_nstages</name>
     <message numerus="yes">
         <location filename="plugins/Runs/qml/reports/startList_classes_nstages.qml" line="14"/>
@@ -6427,6 +6479,14 @@ Přejete si uložit změny?</translation>
         <location filename="plugins/Runs/qml/reports/startList_clubs.qml" line="136"/>
         <source>R </source>
         <translation>P </translation>
+    </message>
+</context>
+<context>
+    <name>startList_clubs_condensed</name>
+    <message>
+        <location filename="plugins/Relays/qml/reports/startList_clubs_condensed.qml" line="8"/>
+        <source>Start list by clubs</source>
+        <translation type="unfinished">Startovní listina po klubech</translation>
     </message>
 </context>
 <context>

--- a/quickevent/app/quickevent/quickevent-cs_CZ.ts
+++ b/quickevent/app/quickevent/quickevent-cs_CZ.ts
@@ -644,7 +644,7 @@ is currently flagged &quot;not running&quot; for this stage (race).
 If you continue, this flag will be removed</source>
         <translation>SI čip je přiřazován k závodníkovi, který má nastaveno,
 že v této etapě (v tomto závodu) nestartuje.
-Pokud budete pokračovat, toto označení bude odebráno.</translation>
+Pokud budete pokračovat, toto označení bude odebráno</translation>
     </message>
     <message>
         <location filename="plugins/CardReader/src/cardreaderwidget.cpp" line="1067"/>
@@ -1101,14 +1101,14 @@ Zvažte nastavení intervalu pro všechny kategorie.</translation>
         <location filename="plugins/Classes/src/classeswidget.cpp" line="639"/>
         <location filename="plugins/Classes/src/classeswidget.cpp" line="713"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Upozornění</translation>
     </message>
     <message>
         <location filename="plugins/Classes/src/classeswidget.cpp" line="458"/>
         <location filename="plugins/Classes/src/classeswidget.cpp" line="639"/>
         <location filename="plugins/Classes/src/classeswidget.cpp" line="713"/>
         <source>Import does not yet support relays.</source>
-        <translation type="unfinished"></translation>
+        <translation>Import zatím nepodporuje štafety.</translation>
     </message>
     <message>
         <location filename="plugins/Classes/src/classeswidget.cpp" line="462"/>
@@ -1822,7 +1822,7 @@ Zvažte nastavení intervalu pro všechny kategorie.</translation>
         <location filename="plugins/Core/src/coreplugin.cpp" line="155"/>
         <source>&amp;About Quick Event</source>
         <oldsource>&amp;About Quick event</oldsource>
-        <translation type="unfinished">O &amp;aplikaci Quick Event</translation>
+        <translation>O &amp;aplikaci Quick Event</translation>
     </message>
     <message>
         <location filename="plugins/Core/src/coreplugin.cpp" line="160"/>
@@ -1837,7 +1837,7 @@ Zvažte nastavení intervalu pro všechny kategorie.</translation>
     <message>
         <location filename="plugins/Core/src/coreplugin.cpp" line="210"/>
         <source>The &lt;b&gt;Quick Event&lt;/b&gt; is an application which helps you to organize the orienteering events.&lt;br/&gt;&lt;br/&gt;version: %1&lt;br/&gt;commit: %7&lt;br/&gt;min. db version: %2&lt;br/&gt;build: %3 %4&lt;br/&gt;SSL build: %5&lt;br/&gt;SSL run: %6</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Quick Event&lt;/b&gt; je aplikace na pořádání závodů v orientačním běhu.&lt;br/&gt;&lt;br/&gt;Verze aplikace: %1&lt;br/&gt;commit: %7&lt;br/&gt;Minimální verze databáze: %2&lt;br/&gt;Datum a čas sestavení: %3 %4&lt;br/&gt;Verze SSL knihovny při sestavení: %5&lt;br/&gt;Verze aktuálně využívané SSL knihovny: %6</translation>
     </message>
     <message>
         <source>The &lt;b&gt;Quick Event&lt;/b&gt; is an application which helps you to organize the orienteering events.&lt;br/&gt;&lt;br/&gt;version: %1&lt;br/&gt;min. db version: %2&lt;br/&gt;build: %3 %4&lt;br/&gt;SSL build: %5&lt;br/&gt;SSL run: %6</source>
@@ -4264,7 +4264,7 @@ zdroj - ORIS-&gt;Závod-&gt;Informace-&gt;Bezpečnostní klíč závodu</transla
     <message>
         <location filename="plugins/Relays/src/relayswidget.cpp" line="93"/>
         <source>Is Running</source>
-        <translation type="unfinished"></translation>
+        <translation>Startuje</translation>
     </message>
     <message>
         <location filename="plugins/Relays/src/relayswidget.cpp" line="119"/>
@@ -4289,7 +4289,7 @@ zdroj - ORIS-&gt;Závod-&gt;Informace-&gt;Bezpečnostní klíč závodu</transla
     <message>
         <location filename="plugins/Relays/src/relayswidget.cpp" line="158"/>
         <source>Add new &amp;vacants</source>
-        <translation type="unfinished"></translation>
+        <translation>Přidat nové &amp;vakanty</translation>
     </message>
     <message>
         <location filename="plugins/Relays/src/relayswidget.cpp" line="164"/>
@@ -4475,17 +4475,17 @@ Stskněte tlačítko pro obnovení pro zobrazení importovaných dat.</translati
     <message>
         <location filename="plugins/Relays/src/relayswidget.cpp" line="718"/>
         <source>vac</source>
-        <translation type="unfinished"></translation>
+        <translation>vak</translation>
     </message>
     <message>
         <location filename="plugins/Relays/src/relayswidget.cpp" line="720"/>
         <source>Enter number of new vacants</source>
-        <translation type="unfinished"></translation>
+        <translation>Zadejte počet nových vakantů</translation>
     </message>
     <message>
         <location filename="plugins/Relays/src/relayswidget.cpp" line="720"/>
         <source>Vacants count for class %1 :</source>
-        <translation type="unfinished"></translation>
+        <translation>Počet vakantů pro kategorii %1 :</translation>
     </message>
 </context>
 <context>
@@ -6431,7 +6431,7 @@ Přejete si uložit změny?</translation>
     <message>
         <location filename="plugins/Relays/qml/reports/startList_classes_condensed.qml" line="8"/>
         <source>Start list by classes</source>
-        <translation type="unfinished">Startovní listina po kategoriích</translation>
+        <translation>Startovní listina po kategoriích</translation>
     </message>
 </context>
 <context>
@@ -6486,7 +6486,7 @@ Přejete si uložit změny?</translation>
     <message>
         <location filename="plugins/Relays/qml/reports/startList_clubs_condensed.qml" line="8"/>
         <source>Start list by clubs</source>
-        <translation type="unfinished">Startovní listina po klubech</translation>
+        <translation>Startovní listina po klubech</translation>
     </message>
 </context>
 <context>

--- a/quickevent/app/quickevent/quickevent-fr_FR.ts
+++ b/quickevent/app/quickevent/quickevent-fr_FR.ts
@@ -1083,20 +1083,34 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="457"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="527"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="634"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="705"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="458"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="639"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="713"/>
+        <source>Warning</source>
+        <translation type="unfinished">Avertissement</translation>
+    </message>
+    <message>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="458"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="639"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="713"/>
+        <source>Import does not yet support relays.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="462"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="532"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="644"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="720"/>
         <source>Open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="634"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="644"/>
         <source>XML files (*.xml);; All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="802"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="817"/>
         <source>Class name &apos;%1&apos; seems to be combined, separate it to more classes?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1748,8 +1762,9 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
     </message>
     <message>
         <location filename="plugins/Core/src/coreplugin.cpp" line="155"/>
-        <source>&amp;About Quick event</source>
-        <translation>&amp;À propos de Quick event</translation>
+        <source>&amp;About Quick Event</source>
+        <oldsource>&amp;About Quick event</oldsource>
+        <translation type="unfinished">&amp;À propos de Quick event</translation>
     </message>
     <message>
         <location filename="plugins/Core/src/coreplugin.cpp" line="160"/>
@@ -1757,17 +1772,17 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
         <translation>À propos de Qt</translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="203"/>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="209"/>
         <source>About Quick Event</source>
         <translation>À propos de Quick Event</translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="204"/>
-        <source>The &lt;b&gt;Quick Event&lt;/b&gt; is an application which helps you to organize the orienteering events.&lt;br/&gt;&lt;br/&gt;version: %1&lt;br/&gt;min. db version: %2&lt;br/&gt;build: %3 %4&lt;br/&gt;SSL build: %5&lt;br/&gt;SSL run: %6</source>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="210"/>
+        <source>The &lt;b&gt;Quick Event&lt;/b&gt; is an application which helps you to organize the orienteering events.&lt;br/&gt;&lt;br/&gt;version: %1&lt;br/&gt;commit: %7&lt;br/&gt;min. db version: %2&lt;br/&gt;build: %3 %4&lt;br/&gt;SSL build: %5&lt;br/&gt;SSL run: %6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="223"/>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="231"/>
         <source>About Qt</source>
         <translation>À propos de Qt</translation>
     </message>
@@ -1896,7 +1911,7 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
 <context>
     <name>DbSchema</name>
     <message>
-        <location filename="plugins/Event/qml/DbSchema.qml" line="507"/>
+        <location filename="plugins/Event/qml/DbSchema.qml" line="511"/>
         <source>Data version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3189,71 +3204,71 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
 <context>
     <name>LegsModel</name>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="65"/>
         <source>Leg</source>
         <comment>relays.leg</comment>
         <translation type="unfinished">Jambe</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="65"/>
         <source>Leg</source>
         <translation type="unfinished">Jambe</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="69"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="66"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="70"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="67"/>
         <source>Reg</source>
         <translation type="unfinished">Ins</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
         <source>SI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="69"/>
         <source>Start</source>
         <translation type="unfinished">Départ</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="70"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="74"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
         <source>NC</source>
         <comment>runs.notCompeting</comment>
         <translation type="unfinished">NP</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="74"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
         <source>Not competing</source>
         <translation type="unfinished">Non partant</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="75"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
         <source>D</source>
         <comment>runs.disqualified</comment>
         <translation type="unfinished">D</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="75"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
         <source>Disqualified</source>
         <translation type="unfinished">Disqualifié</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="76"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
         <source>E</source>
         <comment>runs.misPunch</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="76"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
         <source>Card mispunch</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3542,107 +3557,107 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
 <context>
     <name>OrisImporter</name>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="127"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="128"/>
         <source>JSON document parse error: %1 at: %2 near: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="168"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="169"/>
         <source>Cannot find Oris import ID.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="341"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="342"/>
         <source>Import finished successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="720"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="731"/>
         <source>New entries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="721"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="732"/>
         <source>Edited entries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="722"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="733"/>
         <source>Deleted entries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="725"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="736"/>
         <source>Oris import report</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="735"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="746"/>
         <source>Save without drops</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="742"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="753"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="744"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="755"/>
         <source>Export as ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="744"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="755"/>
         <source>HTML files *.html (*.html)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="751"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="762"/>
         <source>Cannot open file &apos;%1&apos; for writing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="811"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
         <source>Import ORIS Registrations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="811"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
         <source>Year of registration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="833"/>
         <source>Importing registrations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="879"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="890"/>
         <source>Importing clubs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="938"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="949"/>
         <source>Warning</source>
         <translation type="unfinished">Avertissement</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="938"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="949"/>
         <source>For import one-time clubs, you need to fill ORIS Event Key in File-&gt;Event-&gt;Edit event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="963"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="988"/>
         <source>Information</source>
         <translation type="unfinished">Information</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="963"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="988"/>
         <source>No missing one-time clubs found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="969"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="994"/>
         <source>Importing one-time clubs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3970,7 +3985,7 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
     </message>
     <message>
         <location filename="plugins/Relays/src/relaywidget.ui" line="35"/>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="99"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="96"/>
         <source>Relay</source>
         <translation type="unfinished">Relai</translation>
     </message>
@@ -4055,17 +4070,17 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="158"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="155"/>
         <source>Class should be entered.</source>
         <translation type="unfinished">La classe doit être saisie.</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="162"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="159"/>
         <source>Relay ID invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="205"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="202"/>
         <source>Add leg</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4083,12 +4098,12 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaysplugin.cpp" line="823"/>
+        <location filename="plugins/Relays/src/relaysplugin.cpp" line="827"/>
         <source>Relays IOF-XML 3.0 results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaysplugin.cpp" line="964"/>
+        <location filename="plugins/Relays/src/relaysplugin.cpp" line="968"/>
         <source>Relays IOF-XML 3.0 startlist</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4101,225 +4116,250 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
         <translation type="unfinished">Formulaire</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="87"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="88"/>
         <source>Class</source>
         <translation type="unfinished">Classe</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="88"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="89"/>
         <source>Club</source>
         <translation type="unfinished">Club</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="89"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="90"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="90"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="91"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="91"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="92"/>
         <source>Note</source>
         <translation type="unfinished">Remarque</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="117"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="93"/>
+        <source>Is Running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="119"/>
         <source>&amp;Class </source>
         <translation type="unfinished">Classe </translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="144"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="146"/>
         <source>&amp;Relays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="146"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="148"/>
         <source>&amp;Assign numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="151"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="153"/>
         <source>&amp;Import bibs from CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="157"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="158"/>
+        <source>Add new &amp;vacants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="164"/>
         <source>&amp;Print</source>
         <translation type="unfinished">&amp;Afficher</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="159"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="186"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="166"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="193"/>
         <source>&amp;Start list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="160"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="167"/>
         <source>&amp;Classes</source>
         <translation type="unfinished">&amp;Classes</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="163"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="170"/>
         <source>C&amp;lubs</source>
         <translation type="unfinished">C&amp;lubs</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="167"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="192"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="174"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="199"/>
         <source>&amp;Results</source>
         <translation type="unfinished">&amp;Résultats</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="169"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="176"/>
         <source>&amp;After n legs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="174"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="181"/>
         <source>&amp;Overall</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="179"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="186"/>
         <source>Overall condensed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="185"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="192"/>
         <source>E&amp;xport</source>
         <translation type="unfinished">E&amp;xporter</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="188"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="194"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="195"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="201"/>
         <source>IOF-XML 3.0</source>
         <translation type="unfinished">IOF-XML 3.0</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="213"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="220"/>
         <source>--- all ---</source>
         <translation type="unfinished">--- tout ---</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="242"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="249"/>
         <source>Edit Relay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="245"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="252"/>
         <source>Save and &amp;next</source>
         <translation type="unfinished">Enregistrer et passer au suivant</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="277"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="284"/>
         <source>Really delete all the selected relays? This action cannot be reverted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="290"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="297"/>
         <source>Confirm deletion of %1 relays.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="310"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="317"/>
         <source>Dialog</source>
         <translation type="unfinished">Boîte de dialogue</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="310"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="317"/>
         <source>Assign relay numbers method</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="311"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="318"/>
         <source>Random number</source>
         <translation type="unfinished">Nombre aléatoire</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="311"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="318"/>
         <source>In alphabetical order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="431"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="445"/>
         <source>Start list by classes</source>
         <translation type="unfinished">Démarrer la liste par les classes</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="450"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="467"/>
         <source>Start list by clubs</source>
         <translation type="unfinished">Démarrer la liste par les clubs</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="478"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="502"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="526"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="495"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="519"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="543"/>
         <source>Results</source>
         <translation type="unfinished">Résultats</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="536"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="553"/>
         <source>Save as %1</source>
         <translation type="unfinished">Enregistrer sous %1</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="569"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="586"/>
         <source>Import UTF8 text file with comma separated values with first row as header.&lt;br/&gt;Separator is semicolon(;).&lt;br/&gt;Updates only existing relays (key is Club, Relay Name &amp; Class).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="570"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="587"/>
         <source>Each row should have following columns: &lt;ol&gt;&lt;li&gt;Club abbr &lt;i&gt;- key (part1)&lt;/i&gt;&lt;/li&gt;&lt;li&gt;Relay name &lt;i&gt;- key (part2)&lt;/i&gt;&lt;/li&gt;&lt;li&gt;Start number (Bib)&lt;/li&gt;&lt;li&gt;Class (Optional - if not filed, trying to guess from the starting number)&lt;/li&gt;&lt;/ol&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="582"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="599"/>
         <source>Open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="582"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="599"/>
         <source>CSV files (*.csv *.txt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="598"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="615"/>
         <source>Cannot open file &apos;%1&apos; for reading.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="617"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="634"/>
         <source>Fields separation error, invalid CSV format, Error reading CSV line: [%1]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="627"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="644"/>
         <source>Error reading CSV line: [%1]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="638"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="655"/>
         <source>Cannot guess class name from bib: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="643"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="660"/>
         <source>Undefined class name: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="680"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="697"/>
         <source>Information</source>
         <translation type="unfinished">Information</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="680"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="697"/>
         <source>Import file finished. Imported %1 of %2 lines
 
 Press refresh button to show imported data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="718"/>
+        <source>vac</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="720"/>
+        <source>Enter number of new vacants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="720"/>
+        <source>Vacants count for class %1 :</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6151,6 +6191,14 @@ Do you want to save your changes?</source>
     </message>
 </context>
 <context>
+    <name>startList_classes_condensed</name>
+    <message>
+        <location filename="plugins/Relays/qml/reports/startList_classes_condensed.qml" line="8"/>
+        <source>Start list by classes</source>
+        <translation type="unfinished">Démarrer la liste par les classes</translation>
+    </message>
+</context>
+<context>
     <name>startList_classes_nstages</name>
     <message numerus="yes">
         <location filename="plugins/Runs/qml/reports/startList_classes_nstages.qml" line="14"/>
@@ -6193,6 +6241,14 @@ Do you want to save your changes?</source>
         <location filename="plugins/Runs/qml/reports/startList_clubs.qml" line="136"/>
         <source>R </source>
         <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>startList_clubs_condensed</name>
+    <message>
+        <location filename="plugins/Relays/qml/reports/startList_clubs_condensed.qml" line="8"/>
+        <source>Start list by clubs</source>
+        <translation type="unfinished">Démarrer la liste par les clubs</translation>
     </message>
 </context>
 <context>

--- a/quickevent/app/quickevent/quickevent-nb_NO.ts
+++ b/quickevent/app/quickevent/quickevent-nb_NO.ts
@@ -1090,20 +1090,34 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="457"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="527"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="634"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="705"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="458"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="639"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="713"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="458"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="639"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="713"/>
+        <source>Import does not yet support relays.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="462"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="532"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="644"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="720"/>
         <source>Open file</source>
         <translation>Åpne fil</translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="634"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="644"/>
         <source>XML files (*.xml);; All files (*)</source>
         <translation>XML-filer (*.xml);; Alle filer (*)</translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="802"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="817"/>
         <source>Class name &apos;%1&apos; seems to be combined, separate it to more classes?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1703,7 +1717,8 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
     </message>
     <message>
         <location filename="plugins/Core/src/coreplugin.cpp" line="155"/>
-        <source>&amp;About Quick event</source>
+        <source>&amp;About Quick Event</source>
+        <oldsource>&amp;About Quick event</oldsource>
         <translation type="unfinished">&amp; Om Quick Event</translation>
     </message>
     <message>
@@ -1712,17 +1727,17 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
         <translation type="unfinished">Om &amp;Qt</translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="203"/>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="209"/>
         <source>About Quick Event</source>
         <translation type="unfinished">Om Quick Event</translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="204"/>
-        <source>The &lt;b&gt;Quick Event&lt;/b&gt; is an application which helps you to organize the orienteering events.&lt;br/&gt;&lt;br/&gt;version: %1&lt;br/&gt;min. db version: %2&lt;br/&gt;build: %3 %4&lt;br/&gt;SSL build: %5&lt;br/&gt;SSL run: %6</source>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="210"/>
+        <source>The &lt;b&gt;Quick Event&lt;/b&gt; is an application which helps you to organize the orienteering events.&lt;br/&gt;&lt;br/&gt;version: %1&lt;br/&gt;commit: %7&lt;br/&gt;min. db version: %2&lt;br/&gt;build: %3 %4&lt;br/&gt;SSL build: %5&lt;br/&gt;SSL run: %6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="223"/>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="231"/>
         <source>About Qt</source>
         <translation type="unfinished">Om Qt</translation>
     </message>
@@ -1851,7 +1866,7 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
 <context>
     <name>DbSchema</name>
     <message>
-        <location filename="plugins/Event/qml/DbSchema.qml" line="507"/>
+        <location filename="plugins/Event/qml/DbSchema.qml" line="511"/>
         <source>Data version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3149,71 +3164,71 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
 <context>
     <name>LegsModel</name>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="65"/>
         <source>Leg</source>
         <comment>relays.leg</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="65"/>
         <source>Leg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="69"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="66"/>
         <source>Name</source>
         <translation>Navn</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="70"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="67"/>
         <source>Reg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
         <source>SI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="69"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="70"/>
         <source>Time</source>
         <translation>Tid</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="74"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
         <source>NC</source>
         <comment>runs.notCompeting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="74"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
         <source>Not competing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="75"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
         <source>D</source>
         <comment>runs.disqualified</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="75"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
         <source>Disqualified</source>
         <translation>Diskvalifisert</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="76"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
         <source>E</source>
         <comment>runs.misPunch</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="76"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
         <source>Card mispunch</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3498,107 +3513,107 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
 <context>
     <name>OrisImporter</name>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="127"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="128"/>
         <source>JSON document parse error: %1 at: %2 near: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="168"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="169"/>
         <source>Cannot find Oris import ID.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="341"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="342"/>
         <source>Import finished successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="720"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="731"/>
         <source>New entries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="721"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="732"/>
         <source>Edited entries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="722"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="733"/>
         <source>Deleted entries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="725"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="736"/>
         <source>Oris import report</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="735"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="746"/>
         <source>Save without drops</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="742"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="753"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="744"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="755"/>
         <source>Export as ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="744"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="755"/>
         <source>HTML files *.html (*.html)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="751"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="762"/>
         <source>Cannot open file &apos;%1&apos; for writing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="811"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
         <source>Import ORIS Registrations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="811"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
         <source>Year of registration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="833"/>
         <source>Importing registrations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="879"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="890"/>
         <source>Importing clubs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="938"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="949"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="938"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="949"/>
         <source>For import one-time clubs, you need to fill ORIS Event Key in File-&gt;Event-&gt;Edit event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="963"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="988"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="963"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="988"/>
         <source>No missing one-time clubs found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="969"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="994"/>
         <source>Importing one-time clubs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3927,7 +3942,7 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
     </message>
     <message>
         <location filename="plugins/Relays/src/relaywidget.ui" line="35"/>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="99"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="96"/>
         <source>Relay</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4012,17 +4027,17 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="158"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="155"/>
         <source>Class should be entered.</source>
         <translation type="unfinished">Klasse skal skrives inn.</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="162"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="159"/>
         <source>Relay ID invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="205"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="202"/>
         <source>Add leg</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4040,12 +4055,12 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaysplugin.cpp" line="823"/>
+        <location filename="plugins/Relays/src/relaysplugin.cpp" line="827"/>
         <source>Relays IOF-XML 3.0 results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaysplugin.cpp" line="964"/>
+        <location filename="plugins/Relays/src/relaysplugin.cpp" line="968"/>
         <source>Relays IOF-XML 3.0 startlist</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4058,226 +4073,251 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
         <translation type="unfinished">Skjema</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="87"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="88"/>
         <source>Class</source>
         <translation type="unfinished">Klasse</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="88"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="89"/>
         <source>Club</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="89"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="90"/>
         <source>Name</source>
         <translation type="unfinished">Navn</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="90"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="91"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="91"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="92"/>
         <source>Note</source>
         <translation type="unfinished">Merknad</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="117"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="93"/>
+        <source>Is Running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="119"/>
         <source>&amp;Class </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="144"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="146"/>
         <source>&amp;Relays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="146"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="148"/>
         <source>&amp;Assign numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="151"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="153"/>
         <source>&amp;Import bibs from CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="157"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="158"/>
+        <source>Add new &amp;vacants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="164"/>
         <source>&amp;Print</source>
         <translation type="unfinished">&amp;Skriv ut</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="159"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="186"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="166"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="193"/>
         <source>&amp;Start list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="160"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="167"/>
         <source>&amp;Classes</source>
         <translation>&amp;Klasser</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="163"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="170"/>
         <source>C&amp;lubs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="167"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="192"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="174"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="199"/>
         <source>&amp;Results</source>
         <translation>&amp;Resultater</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="169"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="176"/>
         <source>&amp;After n legs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="174"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="181"/>
         <source>&amp;Overall</source>
         <oldsource>&amp;Overal</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="179"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="186"/>
         <source>Overall condensed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="185"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="192"/>
         <source>E&amp;xport</source>
         <translation type="unfinished">E&amp;ksporter</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="188"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="194"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="195"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="201"/>
         <source>IOF-XML 3.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="213"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="220"/>
         <source>--- all ---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="242"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="249"/>
         <source>Edit Relay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="245"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="252"/>
         <source>Save and &amp;next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="277"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="284"/>
         <source>Really delete all the selected relays? This action cannot be reverted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="290"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="297"/>
         <source>Confirm deletion of %1 relays.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="310"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="317"/>
         <source>Dialog</source>
         <translation>Dialog</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="310"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="317"/>
         <source>Assign relay numbers method</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="311"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="318"/>
         <source>Random number</source>
         <translation>Tilfeldig nummer</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="311"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="318"/>
         <source>In alphabetical order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="431"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="445"/>
         <source>Start list by classes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="450"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="467"/>
         <source>Start list by clubs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="478"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="502"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="526"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="495"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="519"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="543"/>
         <source>Results</source>
         <translation type="unfinished">Resultater</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="536"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="553"/>
         <source>Save as %1</source>
         <translation type="unfinished">Lagre som %1</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="569"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="586"/>
         <source>Import UTF8 text file with comma separated values with first row as header.&lt;br/&gt;Separator is semicolon(;).&lt;br/&gt;Updates only existing relays (key is Club, Relay Name &amp; Class).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="570"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="587"/>
         <source>Each row should have following columns: &lt;ol&gt;&lt;li&gt;Club abbr &lt;i&gt;- key (part1)&lt;/i&gt;&lt;/li&gt;&lt;li&gt;Relay name &lt;i&gt;- key (part2)&lt;/i&gt;&lt;/li&gt;&lt;li&gt;Start number (Bib)&lt;/li&gt;&lt;li&gt;Class (Optional - if not filed, trying to guess from the starting number)&lt;/li&gt;&lt;/ol&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="582"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="599"/>
         <source>Open file</source>
         <translation type="unfinished">Åpne fil</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="582"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="599"/>
         <source>CSV files (*.csv *.txt)</source>
         <translation type="unfinished">CSV-filer (*.csv *.txt)</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="598"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="615"/>
         <source>Cannot open file &apos;%1&apos; for reading.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="617"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="634"/>
         <source>Fields separation error, invalid CSV format, Error reading CSV line: [%1]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="627"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="644"/>
         <source>Error reading CSV line: [%1]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="638"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="655"/>
         <source>Cannot guess class name from bib: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="643"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="660"/>
         <source>Undefined class name: &apos;%1&apos;</source>
         <translation type="unfinished">Udefinert klassenavn: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="680"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="697"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="680"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="697"/>
         <source>Import file finished. Imported %1 of %2 lines
 
 Press refresh button to show imported data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="718"/>
+        <source>vac</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="720"/>
+        <source>Enter number of new vacants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="720"/>
+        <source>Vacants count for class %1 :</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6081,6 +6121,14 @@ Do you want to save your changes?</oldsource>
     </message>
 </context>
 <context>
+    <name>startList_classes_condensed</name>
+    <message>
+        <location filename="plugins/Relays/qml/reports/startList_classes_condensed.qml" line="8"/>
+        <source>Start list by classes</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>startList_classes_nstages</name>
     <message numerus="yes">
         <location filename="plugins/Runs/qml/reports/startList_classes_nstages.qml" line="14"/>
@@ -6122,6 +6170,14 @@ Do you want to save your changes?</oldsource>
     <message>
         <location filename="plugins/Runs/qml/reports/startList_clubs.qml" line="136"/>
         <source>R </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>startList_clubs_condensed</name>
+    <message>
+        <location filename="plugins/Relays/qml/reports/startList_clubs_condensed.qml" line="8"/>
+        <source>Start list by clubs</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/quickevent/app/quickevent/quickevent-nl_BE.ts
+++ b/quickevent/app/quickevent/quickevent-nl_BE.ts
@@ -1062,20 +1062,34 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="457"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="527"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="634"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="705"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="458"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="639"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="713"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="458"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="639"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="713"/>
+        <source>Import does not yet support relays.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="462"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="532"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="644"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="720"/>
         <source>Open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="634"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="644"/>
         <source>XML files (*.xml);; All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="802"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="817"/>
         <source>Class name &apos;%1&apos; seems to be combined, separate it to more classes?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1641,7 +1655,8 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
     </message>
     <message>
         <location filename="plugins/Core/src/coreplugin.cpp" line="155"/>
-        <source>&amp;About Quick event</source>
+        <source>&amp;About Quick Event</source>
+        <oldsource>&amp;About Quick event</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1650,17 +1665,17 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="203"/>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="209"/>
         <source>About Quick Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="204"/>
-        <source>The &lt;b&gt;Quick Event&lt;/b&gt; is an application which helps you to organize the orienteering events.&lt;br/&gt;&lt;br/&gt;version: %1&lt;br/&gt;min. db version: %2&lt;br/&gt;build: %3 %4&lt;br/&gt;SSL build: %5&lt;br/&gt;SSL run: %6</source>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="210"/>
+        <source>The &lt;b&gt;Quick Event&lt;/b&gt; is an application which helps you to organize the orienteering events.&lt;br/&gt;&lt;br/&gt;version: %1&lt;br/&gt;commit: %7&lt;br/&gt;min. db version: %2&lt;br/&gt;build: %3 %4&lt;br/&gt;SSL build: %5&lt;br/&gt;SSL run: %6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="223"/>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="231"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1789,7 +1804,7 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
 <context>
     <name>DbSchema</name>
     <message>
-        <location filename="plugins/Event/qml/DbSchema.qml" line="507"/>
+        <location filename="plugins/Event/qml/DbSchema.qml" line="511"/>
         <source>Data version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3082,71 +3097,71 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
 <context>
     <name>LegsModel</name>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="65"/>
         <source>Leg</source>
         <comment>relays.leg</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="65"/>
         <source>Leg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="69"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="66"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="70"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="67"/>
         <source>Reg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
         <source>SI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="69"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="70"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="74"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
         <source>NC</source>
         <comment>runs.notCompeting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="74"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
         <source>Not competing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="75"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
         <source>D</source>
         <comment>runs.disqualified</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="75"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
         <source>Disqualified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="76"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
         <source>E</source>
         <comment>runs.misPunch</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="76"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
         <source>Card mispunch</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3427,107 +3442,107 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
 <context>
     <name>OrisImporter</name>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="127"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="128"/>
         <source>JSON document parse error: %1 at: %2 near: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="168"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="169"/>
         <source>Cannot find Oris import ID.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="341"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="342"/>
         <source>Import finished successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="720"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="731"/>
         <source>New entries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="721"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="732"/>
         <source>Edited entries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="722"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="733"/>
         <source>Deleted entries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="725"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="736"/>
         <source>Oris import report</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="735"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="746"/>
         <source>Save without drops</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="742"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="753"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="744"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="755"/>
         <source>Export as ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="744"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="755"/>
         <source>HTML files *.html (*.html)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="751"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="762"/>
         <source>Cannot open file &apos;%1&apos; for writing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="811"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
         <source>Import ORIS Registrations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="811"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
         <source>Year of registration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="833"/>
         <source>Importing registrations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="879"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="890"/>
         <source>Importing clubs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="938"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="949"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="938"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="949"/>
         <source>For import one-time clubs, you need to fill ORIS Event Key in File-&gt;Event-&gt;Edit event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="963"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="988"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="963"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="988"/>
         <source>No missing one-time clubs found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="969"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="994"/>
         <source>Importing one-time clubs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3855,7 +3870,7 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
     </message>
     <message>
         <location filename="plugins/Relays/src/relaywidget.ui" line="35"/>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="99"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="96"/>
         <source>Relay</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3940,17 +3955,17 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="158"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="155"/>
         <source>Class should be entered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="162"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="159"/>
         <source>Relay ID invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="205"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="202"/>
         <source>Add leg</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3968,12 +3983,12 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaysplugin.cpp" line="823"/>
+        <location filename="plugins/Relays/src/relaysplugin.cpp" line="827"/>
         <source>Relays IOF-XML 3.0 results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaysplugin.cpp" line="964"/>
+        <location filename="plugins/Relays/src/relaysplugin.cpp" line="968"/>
         <source>Relays IOF-XML 3.0 startlist</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,225 +3996,250 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
 <context>
     <name>RelaysWidget</name>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="87"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="88"/>
         <source>Class</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="88"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="89"/>
         <source>Club</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="89"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="90"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="90"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="91"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="91"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="92"/>
         <source>Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="117"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="93"/>
+        <source>Is Running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="119"/>
         <source>&amp;Class </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="144"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="146"/>
         <source>&amp;Relays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="146"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="148"/>
         <source>&amp;Assign numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="151"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="153"/>
         <source>&amp;Import bibs from CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="157"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="158"/>
+        <source>Add new &amp;vacants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="164"/>
         <source>&amp;Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="159"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="186"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="166"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="193"/>
         <source>&amp;Start list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="160"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="167"/>
         <source>&amp;Classes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="163"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="170"/>
         <source>C&amp;lubs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="167"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="192"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="174"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="199"/>
         <source>&amp;Results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="169"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="176"/>
         <source>&amp;After n legs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="174"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="181"/>
         <source>&amp;Overall</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="179"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="186"/>
         <source>Overall condensed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="185"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="192"/>
         <source>E&amp;xport</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="188"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="194"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="195"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="201"/>
         <source>IOF-XML 3.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="213"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="220"/>
         <source>--- all ---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="242"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="249"/>
         <source>Edit Relay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="245"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="252"/>
         <source>Save and &amp;next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="277"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="284"/>
         <source>Really delete all the selected relays? This action cannot be reverted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="290"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="297"/>
         <source>Confirm deletion of %1 relays.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="310"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="317"/>
         <source>Dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="310"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="317"/>
         <source>Assign relay numbers method</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="311"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="318"/>
         <source>Random number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="311"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="318"/>
         <source>In alphabetical order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="431"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="445"/>
         <source>Start list by classes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="450"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="467"/>
         <source>Start list by clubs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="478"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="502"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="526"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="495"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="519"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="543"/>
         <source>Results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="536"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="553"/>
         <source>Save as %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="569"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="586"/>
         <source>Import UTF8 text file with comma separated values with first row as header.&lt;br/&gt;Separator is semicolon(;).&lt;br/&gt;Updates only existing relays (key is Club, Relay Name &amp; Class).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="570"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="587"/>
         <source>Each row should have following columns: &lt;ol&gt;&lt;li&gt;Club abbr &lt;i&gt;- key (part1)&lt;/i&gt;&lt;/li&gt;&lt;li&gt;Relay name &lt;i&gt;- key (part2)&lt;/i&gt;&lt;/li&gt;&lt;li&gt;Start number (Bib)&lt;/li&gt;&lt;li&gt;Class (Optional - if not filed, trying to guess from the starting number)&lt;/li&gt;&lt;/ol&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="582"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="599"/>
         <source>Open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="582"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="599"/>
         <source>CSV files (*.csv *.txt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="598"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="615"/>
         <source>Cannot open file &apos;%1&apos; for reading.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="617"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="634"/>
         <source>Fields separation error, invalid CSV format, Error reading CSV line: [%1]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="627"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="644"/>
         <source>Error reading CSV line: [%1]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="638"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="655"/>
         <source>Cannot guess class name from bib: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="643"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="660"/>
         <source>Undefined class name: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="680"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="697"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="680"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="697"/>
         <source>Import file finished. Imported %1 of %2 lines
 
 Press refresh button to show imported data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="718"/>
+        <source>vac</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="720"/>
+        <source>Enter number of new vacants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="720"/>
+        <source>Vacants count for class %1 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5966,6 +6006,14 @@ Do you want to save your changes?</oldsource>
     </message>
 </context>
 <context>
+    <name>startList_classes_condensed</name>
+    <message>
+        <location filename="plugins/Relays/qml/reports/startList_classes_condensed.qml" line="8"/>
+        <source>Start list by classes</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>startList_classes_nstages</name>
     <message numerus="yes">
         <location filename="plugins/Runs/qml/reports/startList_classes_nstages.qml" line="14"/>
@@ -6007,6 +6055,14 @@ Do you want to save your changes?</oldsource>
     <message>
         <location filename="plugins/Runs/qml/reports/startList_clubs.qml" line="136"/>
         <source>R </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>startList_clubs_condensed</name>
+    <message>
+        <location filename="plugins/Relays/qml/reports/startList_clubs_condensed.qml" line="8"/>
+        <source>Start list by clubs</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/quickevent/app/quickevent/quickevent-pl_PL.ts
+++ b/quickevent/app/quickevent/quickevent-pl_PL.ts
@@ -1062,20 +1062,34 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="457"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="527"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="634"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="705"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="458"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="639"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="713"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="458"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="639"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="713"/>
+        <source>Import does not yet support relays.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="462"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="532"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="644"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="720"/>
         <source>Open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="634"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="644"/>
         <source>XML files (*.xml);; All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="802"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="817"/>
         <source>Class name &apos;%1&apos; seems to be combined, separate it to more classes?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1641,7 +1655,8 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
     </message>
     <message>
         <location filename="plugins/Core/src/coreplugin.cpp" line="155"/>
-        <source>&amp;About Quick event</source>
+        <source>&amp;About Quick Event</source>
+        <oldsource>&amp;About Quick event</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1650,17 +1665,17 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="203"/>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="209"/>
         <source>About Quick Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="204"/>
-        <source>The &lt;b&gt;Quick Event&lt;/b&gt; is an application which helps you to organize the orienteering events.&lt;br/&gt;&lt;br/&gt;version: %1&lt;br/&gt;min. db version: %2&lt;br/&gt;build: %3 %4&lt;br/&gt;SSL build: %5&lt;br/&gt;SSL run: %6</source>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="210"/>
+        <source>The &lt;b&gt;Quick Event&lt;/b&gt; is an application which helps you to organize the orienteering events.&lt;br/&gt;&lt;br/&gt;version: %1&lt;br/&gt;commit: %7&lt;br/&gt;min. db version: %2&lt;br/&gt;build: %3 %4&lt;br/&gt;SSL build: %5&lt;br/&gt;SSL run: %6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="223"/>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="231"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1789,7 +1804,7 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
 <context>
     <name>DbSchema</name>
     <message>
-        <location filename="plugins/Event/qml/DbSchema.qml" line="507"/>
+        <location filename="plugins/Event/qml/DbSchema.qml" line="511"/>
         <source>Data version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3082,71 +3097,71 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
 <context>
     <name>LegsModel</name>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="65"/>
         <source>Leg</source>
         <comment>relays.leg</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="65"/>
         <source>Leg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="69"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="66"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="70"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="67"/>
         <source>Reg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
         <source>SI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="69"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="70"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="74"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
         <source>NC</source>
         <comment>runs.notCompeting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="74"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
         <source>Not competing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="75"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
         <source>D</source>
         <comment>runs.disqualified</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="75"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
         <source>Disqualified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="76"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
         <source>E</source>
         <comment>runs.misPunch</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="76"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
         <source>Card mispunch</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3427,107 +3442,107 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
 <context>
     <name>OrisImporter</name>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="127"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="128"/>
         <source>JSON document parse error: %1 at: %2 near: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="168"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="169"/>
         <source>Cannot find Oris import ID.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="341"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="342"/>
         <source>Import finished successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="720"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="731"/>
         <source>New entries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="721"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="732"/>
         <source>Edited entries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="722"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="733"/>
         <source>Deleted entries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="725"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="736"/>
         <source>Oris import report</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="735"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="746"/>
         <source>Save without drops</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="742"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="753"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="744"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="755"/>
         <source>Export as ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="744"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="755"/>
         <source>HTML files *.html (*.html)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="751"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="762"/>
         <source>Cannot open file &apos;%1&apos; for writing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="811"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
         <source>Import ORIS Registrations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="811"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
         <source>Year of registration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="833"/>
         <source>Importing registrations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="879"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="890"/>
         <source>Importing clubs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="938"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="949"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="938"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="949"/>
         <source>For import one-time clubs, you need to fill ORIS Event Key in File-&gt;Event-&gt;Edit event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="963"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="988"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="963"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="988"/>
         <source>No missing one-time clubs found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="969"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="994"/>
         <source>Importing one-time clubs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3855,7 +3870,7 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
     </message>
     <message>
         <location filename="plugins/Relays/src/relaywidget.ui" line="35"/>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="99"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="96"/>
         <source>Relay</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3940,17 +3955,17 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="158"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="155"/>
         <source>Class should be entered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="162"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="159"/>
         <source>Relay ID invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="205"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="202"/>
         <source>Add leg</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3968,12 +3983,12 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaysplugin.cpp" line="823"/>
+        <location filename="plugins/Relays/src/relaysplugin.cpp" line="827"/>
         <source>Relays IOF-XML 3.0 results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaysplugin.cpp" line="964"/>
+        <location filename="plugins/Relays/src/relaysplugin.cpp" line="968"/>
         <source>Relays IOF-XML 3.0 startlist</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,225 +3996,250 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
 <context>
     <name>RelaysWidget</name>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="87"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="88"/>
         <source>Class</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="88"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="89"/>
         <source>Club</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="89"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="90"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="90"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="91"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="91"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="92"/>
         <source>Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="117"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="93"/>
+        <source>Is Running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="119"/>
         <source>&amp;Class </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="144"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="146"/>
         <source>&amp;Relays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="146"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="148"/>
         <source>&amp;Assign numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="151"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="153"/>
         <source>&amp;Import bibs from CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="157"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="158"/>
+        <source>Add new &amp;vacants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="164"/>
         <source>&amp;Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="159"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="186"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="166"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="193"/>
         <source>&amp;Start list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="160"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="167"/>
         <source>&amp;Classes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="163"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="170"/>
         <source>C&amp;lubs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="167"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="192"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="174"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="199"/>
         <source>&amp;Results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="169"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="176"/>
         <source>&amp;After n legs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="174"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="181"/>
         <source>&amp;Overall</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="179"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="186"/>
         <source>Overall condensed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="185"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="192"/>
         <source>E&amp;xport</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="188"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="194"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="195"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="201"/>
         <source>IOF-XML 3.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="213"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="220"/>
         <source>--- all ---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="242"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="249"/>
         <source>Edit Relay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="245"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="252"/>
         <source>Save and &amp;next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="277"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="284"/>
         <source>Really delete all the selected relays? This action cannot be reverted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="290"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="297"/>
         <source>Confirm deletion of %1 relays.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="310"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="317"/>
         <source>Dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="310"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="317"/>
         <source>Assign relay numbers method</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="311"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="318"/>
         <source>Random number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="311"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="318"/>
         <source>In alphabetical order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="431"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="445"/>
         <source>Start list by classes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="450"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="467"/>
         <source>Start list by clubs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="478"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="502"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="526"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="495"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="519"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="543"/>
         <source>Results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="536"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="553"/>
         <source>Save as %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="569"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="586"/>
         <source>Import UTF8 text file with comma separated values with first row as header.&lt;br/&gt;Separator is semicolon(;).&lt;br/&gt;Updates only existing relays (key is Club, Relay Name &amp; Class).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="570"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="587"/>
         <source>Each row should have following columns: &lt;ol&gt;&lt;li&gt;Club abbr &lt;i&gt;- key (part1)&lt;/i&gt;&lt;/li&gt;&lt;li&gt;Relay name &lt;i&gt;- key (part2)&lt;/i&gt;&lt;/li&gt;&lt;li&gt;Start number (Bib)&lt;/li&gt;&lt;li&gt;Class (Optional - if not filed, trying to guess from the starting number)&lt;/li&gt;&lt;/ol&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="582"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="599"/>
         <source>Open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="582"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="599"/>
         <source>CSV files (*.csv *.txt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="598"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="615"/>
         <source>Cannot open file &apos;%1&apos; for reading.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="617"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="634"/>
         <source>Fields separation error, invalid CSV format, Error reading CSV line: [%1]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="627"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="644"/>
         <source>Error reading CSV line: [%1]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="638"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="655"/>
         <source>Cannot guess class name from bib: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="643"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="660"/>
         <source>Undefined class name: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="680"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="697"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="680"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="697"/>
         <source>Import file finished. Imported %1 of %2 lines
 
 Press refresh button to show imported data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="718"/>
+        <source>vac</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="720"/>
+        <source>Enter number of new vacants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="720"/>
+        <source>Vacants count for class %1 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5971,6 +6011,14 @@ Do you want to save your changes?</oldsource>
     </message>
 </context>
 <context>
+    <name>startList_classes_condensed</name>
+    <message>
+        <location filename="plugins/Relays/qml/reports/startList_classes_condensed.qml" line="8"/>
+        <source>Start list by classes</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>startList_classes_nstages</name>
     <message numerus="yes">
         <location filename="plugins/Runs/qml/reports/startList_classes_nstages.qml" line="14"/>
@@ -6013,6 +6061,14 @@ Do you want to save your changes?</oldsource>
     <message>
         <location filename="plugins/Runs/qml/reports/startList_clubs.qml" line="136"/>
         <source>R </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>startList_clubs_condensed</name>
+    <message>
+        <location filename="plugins/Relays/qml/reports/startList_clubs_condensed.qml" line="8"/>
+        <source>Start list by clubs</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/quickevent/app/quickevent/quickevent-ru_RU.ts
+++ b/quickevent/app/quickevent/quickevent-ru_RU.ts
@@ -1087,20 +1087,34 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="457"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="527"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="634"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="705"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="458"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="639"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="713"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="458"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="639"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="713"/>
+        <source>Import does not yet support relays.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="462"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="532"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="644"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="720"/>
         <source>Open file</source>
         <translation>Открыть файл</translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="634"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="644"/>
         <source>XML files (*.xml);; All files (*)</source>
         <translation>XML-файлы (*.xml);; Все файлы (*)</translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="802"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="817"/>
         <source>Class name &apos;%1&apos; seems to be combined, separate it to more classes?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1692,7 +1706,8 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
     </message>
     <message>
         <location filename="plugins/Core/src/coreplugin.cpp" line="155"/>
-        <source>&amp;About Quick event</source>
+        <source>&amp;About Quick Event</source>
+        <oldsource>&amp;About Quick event</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1701,17 +1716,17 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
         <translation type="unfinished">О &amp;Qt</translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="203"/>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="209"/>
         <source>About Quick Event</source>
         <translation type="unfinished">О Quick Event</translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="204"/>
-        <source>The &lt;b&gt;Quick Event&lt;/b&gt; is an application which helps you to organize the orienteering events.&lt;br/&gt;&lt;br/&gt;version: %1&lt;br/&gt;min. db version: %2&lt;br/&gt;build: %3 %4&lt;br/&gt;SSL build: %5&lt;br/&gt;SSL run: %6</source>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="210"/>
+        <source>The &lt;b&gt;Quick Event&lt;/b&gt; is an application which helps you to organize the orienteering events.&lt;br/&gt;&lt;br/&gt;version: %1&lt;br/&gt;commit: %7&lt;br/&gt;min. db version: %2&lt;br/&gt;build: %3 %4&lt;br/&gt;SSL build: %5&lt;br/&gt;SSL run: %6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="223"/>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="231"/>
         <source>About Qt</source>
         <translation type="unfinished">О Qt</translation>
     </message>
@@ -1840,7 +1855,7 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
 <context>
     <name>DbSchema</name>
     <message>
-        <location filename="plugins/Event/qml/DbSchema.qml" line="507"/>
+        <location filename="plugins/Event/qml/DbSchema.qml" line="511"/>
         <source>Data version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3134,71 +3149,71 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
 <context>
     <name>LegsModel</name>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="65"/>
         <source>Leg</source>
         <comment>relays.leg</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="65"/>
         <source>Leg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="69"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="66"/>
         <source>Name</source>
         <translation type="unfinished">Имя</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="70"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="67"/>
         <source>Reg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
         <source>SI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="69"/>
         <source>Start</source>
         <translation type="unfinished">Старт</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="70"/>
         <source>Time</source>
         <translation type="unfinished">Время</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="74"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
         <source>NC</source>
         <comment>runs.notCompeting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="74"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
         <source>Not competing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="75"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
         <source>D</source>
         <comment>runs.disqualified</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="75"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
         <source>Disqualified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="76"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
         <source>E</source>
         <comment>runs.misPunch</comment>
         <translation type="unfinished">E</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="76"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
         <source>Card mispunch</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3479,107 +3494,107 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
 <context>
     <name>OrisImporter</name>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="127"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="128"/>
         <source>JSON document parse error: %1 at: %2 near: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="168"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="169"/>
         <source>Cannot find Oris import ID.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="341"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="342"/>
         <source>Import finished successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="720"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="731"/>
         <source>New entries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="721"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="732"/>
         <source>Edited entries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="722"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="733"/>
         <source>Deleted entries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="725"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="736"/>
         <source>Oris import report</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="735"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="746"/>
         <source>Save without drops</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="742"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="753"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="744"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="755"/>
         <source>Export as ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="744"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="755"/>
         <source>HTML files *.html (*.html)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="751"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="762"/>
         <source>Cannot open file &apos;%1&apos; for writing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="811"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
         <source>Import ORIS Registrations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="811"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
         <source>Year of registration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="833"/>
         <source>Importing registrations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="879"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="890"/>
         <source>Importing clubs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="938"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="949"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="938"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="949"/>
         <source>For import one-time clubs, you need to fill ORIS Event Key in File-&gt;Event-&gt;Edit event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="963"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="988"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="963"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="988"/>
         <source>No missing one-time clubs found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="969"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="994"/>
         <source>Importing one-time clubs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3907,7 +3922,7 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
     </message>
     <message>
         <location filename="plugins/Relays/src/relaywidget.ui" line="35"/>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="99"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="96"/>
         <source>Relay</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3992,17 +4007,17 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="158"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="155"/>
         <source>Class should be entered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="162"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="159"/>
         <source>Relay ID invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="205"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="202"/>
         <source>Add leg</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4020,12 +4035,12 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaysplugin.cpp" line="823"/>
+        <location filename="plugins/Relays/src/relaysplugin.cpp" line="827"/>
         <source>Relays IOF-XML 3.0 results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaysplugin.cpp" line="964"/>
+        <location filename="plugins/Relays/src/relaysplugin.cpp" line="968"/>
         <source>Relays IOF-XML 3.0 startlist</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4038,225 +4053,250 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
         <translation type="unfinished">Форма</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="87"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="88"/>
         <source>Class</source>
         <translation type="unfinished">Класс</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="88"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="89"/>
         <source>Club</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="89"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="90"/>
         <source>Name</source>
         <translation type="unfinished">Имя</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="90"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="91"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="91"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="92"/>
         <source>Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="117"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="93"/>
+        <source>Is Running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="119"/>
         <source>&amp;Class </source>
         <translation type="unfinished">&amp;Класс </translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="144"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="146"/>
         <source>&amp;Relays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="146"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="148"/>
         <source>&amp;Assign numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="151"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="153"/>
         <source>&amp;Import bibs from CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="157"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="158"/>
+        <source>Add new &amp;vacants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="164"/>
         <source>&amp;Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="159"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="186"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="166"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="193"/>
         <source>&amp;Start list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="160"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="167"/>
         <source>&amp;Classes</source>
         <translation type="unfinished">&amp;Классы</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="163"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="170"/>
         <source>C&amp;lubs</source>
         <translation type="unfinished">К&amp;лубы</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="167"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="192"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="174"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="199"/>
         <source>&amp;Results</source>
         <translation type="unfinished">&amp;Результаты</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="169"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="176"/>
         <source>&amp;After n legs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="174"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="181"/>
         <source>&amp;Overall</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="179"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="186"/>
         <source>Overall condensed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="185"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="192"/>
         <source>E&amp;xport</source>
         <translation type="unfinished">Э&amp;кпорт</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="188"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="194"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="195"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="201"/>
         <source>IOF-XML 3.0</source>
         <translation type="unfinished">IOF-XML 3.0</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="213"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="220"/>
         <source>--- all ---</source>
         <translation type="unfinished">--- все ---</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="242"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="249"/>
         <source>Edit Relay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="245"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="252"/>
         <source>Save and &amp;next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="277"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="284"/>
         <source>Really delete all the selected relays? This action cannot be reverted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="290"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="297"/>
         <source>Confirm deletion of %1 relays.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="310"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="317"/>
         <source>Dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="310"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="317"/>
         <source>Assign relay numbers method</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="311"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="318"/>
         <source>Random number</source>
         <translation type="unfinished">Случайное число</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="311"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="318"/>
         <source>In alphabetical order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="431"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="445"/>
         <source>Start list by classes</source>
         <translation type="unfinished">Стартовый список по классам</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="450"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="467"/>
         <source>Start list by clubs</source>
         <translation type="unfinished">Стартовый список по клубам</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="478"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="502"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="526"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="495"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="519"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="543"/>
         <source>Results</source>
         <translation type="unfinished">Результаты</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="536"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="553"/>
         <source>Save as %1</source>
         <translation type="unfinished">Сохранить как %1</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="569"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="586"/>
         <source>Import UTF8 text file with comma separated values with first row as header.&lt;br/&gt;Separator is semicolon(;).&lt;br/&gt;Updates only existing relays (key is Club, Relay Name &amp; Class).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="570"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="587"/>
         <source>Each row should have following columns: &lt;ol&gt;&lt;li&gt;Club abbr &lt;i&gt;- key (part1)&lt;/i&gt;&lt;/li&gt;&lt;li&gt;Relay name &lt;i&gt;- key (part2)&lt;/i&gt;&lt;/li&gt;&lt;li&gt;Start number (Bib)&lt;/li&gt;&lt;li&gt;Class (Optional - if not filed, trying to guess from the starting number)&lt;/li&gt;&lt;/ol&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="582"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="599"/>
         <source>Open file</source>
         <translation type="unfinished">Открыть файл</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="582"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="599"/>
         <source>CSV files (*.csv *.txt)</source>
         <translation type="unfinished">CSV файлы (*.csv *.txt)</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="598"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="615"/>
         <source>Cannot open file &apos;%1&apos; for reading.</source>
         <translation type="unfinished">Не удается открыть файл &apos;%1&apos; для чтения.</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="617"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="634"/>
         <source>Fields separation error, invalid CSV format, Error reading CSV line: [%1]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="627"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="644"/>
         <source>Error reading CSV line: [%1]</source>
         <translation type="unfinished">Ошибка чтения строки CSV: [% 1]</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="638"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="655"/>
         <source>Cannot guess class name from bib: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="643"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="660"/>
         <source>Undefined class name: &apos;%1&apos;</source>
         <translation type="unfinished">Неопределенное имя класса: &apos;% 1&apos;</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="680"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="697"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="680"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="697"/>
         <source>Import file finished. Imported %1 of %2 lines
 
 Press refresh button to show imported data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="718"/>
+        <source>vac</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="720"/>
+        <source>Enter number of new vacants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="720"/>
+        <source>Vacants count for class %1 :</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6057,6 +6097,14 @@ Do you want to save your changes?</oldsource>
     </message>
 </context>
 <context>
+    <name>startList_classes_condensed</name>
+    <message>
+        <location filename="plugins/Relays/qml/reports/startList_classes_condensed.qml" line="8"/>
+        <source>Start list by classes</source>
+        <translation type="unfinished">Стартовый список по классам</translation>
+    </message>
+</context>
+<context>
     <name>startList_classes_nstages</name>
     <message numerus="yes">
         <location filename="plugins/Runs/qml/reports/startList_classes_nstages.qml" line="14"/>
@@ -6101,6 +6149,14 @@ Do you want to save your changes?</oldsource>
         <location filename="plugins/Runs/qml/reports/startList_clubs.qml" line="136"/>
         <source>R </source>
         <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>startList_clubs_condensed</name>
+    <message>
+        <location filename="plugins/Relays/qml/reports/startList_clubs_condensed.qml" line="8"/>
+        <source>Start list by clubs</source>
+        <translation type="unfinished">Стартовый список по клубам</translation>
     </message>
 </context>
 <context>

--- a/quickevent/app/quickevent/quickevent-uk_UA.ts
+++ b/quickevent/app/quickevent/quickevent-uk_UA.ts
@@ -1090,20 +1090,34 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
         <translation>Видалити всі дистанції для забігу %1?</translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="457"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="527"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="634"/>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="705"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="458"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="639"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="713"/>
+        <source>Warning</source>
+        <translation type="unfinished">Попередження</translation>
+    </message>
+    <message>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="458"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="639"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="713"/>
+        <source>Import does not yet support relays.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="462"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="532"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="644"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="720"/>
         <source>Open file</source>
         <translation>Відкрити файл</translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="634"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="644"/>
         <source>XML files (*.xml);; All files (*)</source>
         <translation>Файли XML (*.xml);; Усі файли (*)</translation>
     </message>
     <message>
-        <location filename="plugins/Classes/src/classeswidget.cpp" line="802"/>
+        <location filename="plugins/Classes/src/classeswidget.cpp" line="817"/>
         <source>Class name &apos;%1&apos; seems to be combined, separate it to more classes?</source>
         <translation>Назва групи «%1»; мабуть, комбінована; розділити їх на більше груп?</translation>
     </message>
@@ -1795,8 +1809,9 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
     </message>
     <message>
         <location filename="plugins/Core/src/coreplugin.cpp" line="155"/>
-        <source>&amp;About Quick event</source>
-        <translation>&amp;Про Quick event</translation>
+        <source>&amp;About Quick Event</source>
+        <oldsource>&amp;About Quick event</oldsource>
+        <translation type="unfinished">&amp;Про Quick event</translation>
     </message>
     <message>
         <location filename="plugins/Core/src/coreplugin.cpp" line="160"/>
@@ -1804,17 +1819,21 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
         <translation>Про &amp;Qt</translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="203"/>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="209"/>
         <source>About Quick Event</source>
         <translation>Про Quick Event</translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="204"/>
-        <source>The &lt;b&gt;Quick Event&lt;/b&gt; is an application which helps you to organize the orienteering events.&lt;br/&gt;&lt;br/&gt;version: %1&lt;br/&gt;min. db version: %2&lt;br/&gt;build: %3 %4&lt;br/&gt;SSL build: %5&lt;br/&gt;SSL run: %6</source>
-        <translation>&lt;b&gt;Quick Event&lt;/b&gt; — це додаток, який допомагає в організації тренувань і змагань зі спортивного оруєнтування.&lt;br/&gt;&lt;br/&gt;версія: %1&lt;br/&gt;min. верся db: %2&lt;br/&gt;складання: %3 %4&lt;br/&gt;збірка SSL: %5&lt;br/&gt;запуск SSL: %6</translation>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="210"/>
+        <source>The &lt;b&gt;Quick Event&lt;/b&gt; is an application which helps you to organize the orienteering events.&lt;br/&gt;&lt;br/&gt;version: %1&lt;br/&gt;commit: %7&lt;br/&gt;min. db version: %2&lt;br/&gt;build: %3 %4&lt;br/&gt;SSL build: %5&lt;br/&gt;SSL run: %6</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Core/src/coreplugin.cpp" line="223"/>
+        <source>The &lt;b&gt;Quick Event&lt;/b&gt; is an application which helps you to organize the orienteering events.&lt;br/&gt;&lt;br/&gt;version: %1&lt;br/&gt;min. db version: %2&lt;br/&gt;build: %3 %4&lt;br/&gt;SSL build: %5&lt;br/&gt;SSL run: %6</source>
+        <translation type="vanished">&lt;b&gt;Quick Event&lt;/b&gt; — це додаток, який допомагає в організації тренувань і змагань зі спортивного оруєнтування.&lt;br/&gt;&lt;br/&gt;версія: %1&lt;br/&gt;min. верся db: %2&lt;br/&gt;складання: %3 %4&lt;br/&gt;збірка SSL: %5&lt;br/&gt;запуск SSL: %6</translation>
+    </message>
+    <message>
+        <location filename="plugins/Core/src/coreplugin.cpp" line="231"/>
         <source>About Qt</source>
         <translation>Про Qt</translation>
     </message>
@@ -1955,7 +1974,7 @@ Consider setting &quot;Interval&quot; column for all classes before continuing.<
 <context>
     <name>DbSchema</name>
     <message>
-        <location filename="plugins/Event/qml/DbSchema.qml" line="507"/>
+        <location filename="plugins/Event/qml/DbSchema.qml" line="511"/>
         <source>Data version</source>
         <translation>Версія даних</translation>
     </message>
@@ -3270,71 +3289,71 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
 <context>
     <name>LegsModel</name>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="65"/>
         <source>Leg</source>
         <comment>relays.leg</comment>
         <translation>Етап</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="65"/>
         <source>Leg</source>
         <translation>Етап</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="69"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="66"/>
         <source>Name</source>
         <translation>Ім’я</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="70"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="67"/>
         <source>Reg</source>
         <translation>Реє</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="68"/>
         <source>SI</source>
         <translation>ЧИП</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="69"/>
         <source>Start</source>
         <translation>Старт</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="70"/>
         <source>Time</source>
         <translation>Час</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="74"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
         <source>NC</source>
         <comment>runs.notCompeting</comment>
         <translation>NC</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="74"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="71"/>
         <source>Not competing</source>
         <translation>Не змагається</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="75"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
         <source>D</source>
         <comment>runs.disqualified</comment>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="75"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="72"/>
         <source>Disqualified</source>
         <translation>Дискваліфікація</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="76"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
         <source>E</source>
         <comment>runs.misPunch</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="76"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="73"/>
         <source>Card mispunch</source>
         <translation>Неправильна відмітка</translation>
     </message>
@@ -3627,107 +3646,107 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
 <context>
     <name>OrisImporter</name>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="127"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="128"/>
         <source>JSON document parse error: %1 at: %2 near: %3</source>
         <translation>Помилка розбирання документу JSON: %1 у: %2 коло: %3</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="168"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="169"/>
         <source>Cannot find Oris import ID.</source>
         <translation>Неможливо знайти ІД імпорту Oris.</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="341"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="342"/>
         <source>Import finished successfully.</source>
         <translation>Імпортовано успішно.</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="720"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="731"/>
         <source>New entries</source>
         <translation>Нові записи</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="721"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="732"/>
         <source>Edited entries</source>
         <translation>Відредаговані записи</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="722"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="733"/>
         <source>Deleted entries</source>
         <translation>Видалені записи</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="725"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="736"/>
         <source>Oris import report</source>
         <translation>Звіт імпорту Oris</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="735"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="746"/>
         <source>Save without drops</source>
         <translation>Записати без видалення</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="742"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="753"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="744"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="755"/>
         <source>Export as ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="744"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="755"/>
         <source>HTML files *.html (*.html)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="751"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="762"/>
         <source>Cannot open file &apos;%1&apos; for writing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="811"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
         <source>Import ORIS Registrations</source>
         <translation>Імпорт реєстрацій ORIS</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="811"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
         <source>Year of registration:</source>
         <translation>Рік реєстрації:</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="822"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="833"/>
         <source>Importing registrations</source>
         <translation>Імпорт реєстрацій</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="879"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="890"/>
         <source>Importing clubs</source>
         <translation>Імпорт клубів</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="938"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="949"/>
         <source>Warning</source>
         <translation type="unfinished">Попередження</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="938"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="949"/>
         <source>For import one-time clubs, you need to fill ORIS Event Key in File-&gt;Event-&gt;Edit event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="963"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="988"/>
         <source>Information</source>
         <translation type="unfinished">Інформація</translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="963"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="988"/>
         <source>No missing one-time clubs found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Oris/src/orisimporter.cpp" line="969"/>
+        <location filename="plugins/Oris/src/orisimporter.cpp" line="994"/>
         <source>Importing one-time clubs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4055,7 +4074,7 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
     </message>
     <message>
         <location filename="plugins/Relays/src/relaywidget.ui" line="35"/>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="99"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="96"/>
         <source>Relay</source>
         <translation>Естафета</translation>
     </message>
@@ -4140,17 +4159,17 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="158"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="155"/>
         <source>Class should be entered.</source>
         <translation>Група повинна бути вказана.</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="162"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="159"/>
         <source>Relay ID invalid.</source>
         <translation>ІД естафети некоректний.</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaywidget.cpp" line="205"/>
+        <location filename="plugins/Relays/src/relaywidget.cpp" line="202"/>
         <source>Add leg</source>
         <translation>Додати етап</translation>
     </message>
@@ -4168,12 +4187,12 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
         <translation>&amp;Естафети</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaysplugin.cpp" line="823"/>
+        <location filename="plugins/Relays/src/relaysplugin.cpp" line="827"/>
         <source>Relays IOF-XML 3.0 results</source>
         <translation>Результати естафет IOF-XML 3.0</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relaysplugin.cpp" line="964"/>
+        <location filename="plugins/Relays/src/relaysplugin.cpp" line="968"/>
         <source>Relays IOF-XML 3.0 startlist</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4186,225 +4205,250 @@ source - ORIS-&gt;Event-&gt;Information-&gt;Event key</source>
         <translation>Форма</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="87"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="88"/>
         <source>Class</source>
         <translation>Група</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="88"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="89"/>
         <source>Club</source>
         <translation>Клуб</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="89"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="90"/>
         <source>Name</source>
         <translation>Ім’я</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="90"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="91"/>
         <source>Number</source>
         <translation>Номер</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="91"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="92"/>
         <source>Note</source>
         <translation>Нотатки</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="117"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="93"/>
+        <source>Is Running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="119"/>
         <source>&amp;Class </source>
         <translation>&amp;Група </translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="144"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="146"/>
         <source>&amp;Relays</source>
         <translation>&amp;Естафети</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="146"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="148"/>
         <source>&amp;Assign numbers</source>
         <translation>&amp;Призначити номери</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="151"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="153"/>
         <source>&amp;Import bibs from CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="157"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="158"/>
+        <source>Add new &amp;vacants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="164"/>
         <source>&amp;Print</source>
         <translation>&amp;Друк</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="159"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="186"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="166"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="193"/>
         <source>&amp;Start list</source>
         <translation>&amp;Стартовий протокол</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="160"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="167"/>
         <source>&amp;Classes</source>
         <translation>&amp;Групи</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="163"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="170"/>
         <source>C&amp;lubs</source>
         <translation>К&amp;луби</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="167"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="192"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="174"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="199"/>
         <source>&amp;Results</source>
         <translation>&amp;Результати</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="169"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="176"/>
         <source>&amp;After n legs</source>
         <translation>&amp;Після n етапів</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="174"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="181"/>
         <source>&amp;Overall</source>
         <translation>&amp;Усього</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="179"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="186"/>
         <source>Overall condensed</source>
         <translation>Усього стиснено</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="185"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="192"/>
         <source>E&amp;xport</source>
         <translation>Ек&amp;cпорт</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="188"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="194"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="195"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="201"/>
         <source>IOF-XML 3.0</source>
         <translation>IOF-XML 3.0</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="213"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="220"/>
         <source>--- all ---</source>
         <translation>--- усі ---</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="242"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="249"/>
         <source>Edit Relay</source>
         <translation>Редагувати естафету</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="245"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="252"/>
         <source>Save and &amp;next</source>
         <translation>Зберегти і &amp;далі</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="277"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="284"/>
         <source>Really delete all the selected relays? This action cannot be reverted.</source>
         <translation>Справді видалити всі вибрані естафети? Цю дію не можна обернути.</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="290"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="297"/>
         <source>Confirm deletion of %1 relays.</source>
         <translation>Підтвердьте видалення %1 естафет.</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="310"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="317"/>
         <source>Dialog</source>
         <translation>Діалог</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="310"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="317"/>
         <source>Assign relay numbers method</source>
         <translation>Метод призначення номерів естафет</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="311"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="318"/>
         <source>Random number</source>
         <translation>Випадковий номер</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="311"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="318"/>
         <source>In alphabetical order</source>
         <translation>В алфавітному порядку</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="431"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="445"/>
         <source>Start list by classes</source>
         <translation>Стартовий протокол по групах</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="450"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="467"/>
         <source>Start list by clubs</source>
         <translation>Стартовий протокол по клубах</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="478"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="502"/>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="526"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="495"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="519"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="543"/>
         <source>Results</source>
         <translation>Результати</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="536"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="553"/>
         <source>Save as %1</source>
         <translation>Зберегти як %1</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="569"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="586"/>
         <source>Import UTF8 text file with comma separated values with first row as header.&lt;br/&gt;Separator is semicolon(;).&lt;br/&gt;Updates only existing relays (key is Club, Relay Name &amp; Class).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="570"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="587"/>
         <source>Each row should have following columns: &lt;ol&gt;&lt;li&gt;Club abbr &lt;i&gt;- key (part1)&lt;/i&gt;&lt;/li&gt;&lt;li&gt;Relay name &lt;i&gt;- key (part2)&lt;/i&gt;&lt;/li&gt;&lt;li&gt;Start number (Bib)&lt;/li&gt;&lt;li&gt;Class (Optional - if not filed, trying to guess from the starting number)&lt;/li&gt;&lt;/ol&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="582"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="599"/>
         <source>Open file</source>
         <translation type="unfinished">Відкрити файл</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="582"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="599"/>
         <source>CSV files (*.csv *.txt)</source>
         <translation type="unfinished">Файли CSV (*.csv *.txt)</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="598"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="615"/>
         <source>Cannot open file &apos;%1&apos; for reading.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="617"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="634"/>
         <source>Fields separation error, invalid CSV format, Error reading CSV line: [%1]</source>
         <translation type="unfinished">Помилка розділення полів, некоректний формат CSV, Помилка читання рядка CSV: [%1]</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="627"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="644"/>
         <source>Error reading CSV line: [%1]</source>
         <translation type="unfinished">Помилка читання рядка CSV: [%1]</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="638"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="655"/>
         <source>Cannot guess class name from bib: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="643"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="660"/>
         <source>Undefined class name: &apos;%1&apos;</source>
         <translation type="unfinished">Невизначена назва групи: «%1»</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="680"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="697"/>
         <source>Information</source>
         <translation type="unfinished">Інформація</translation>
     </message>
     <message>
-        <location filename="plugins/Relays/src/relayswidget.cpp" line="680"/>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="697"/>
         <source>Import file finished. Imported %1 of %2 lines
 
 Press refresh button to show imported data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="718"/>
+        <source>vac</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="720"/>
+        <source>Enter number of new vacants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="plugins/Relays/src/relayswidget.cpp" line="720"/>
+        <source>Vacants count for class %1 :</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6331,6 +6375,14 @@ Do you want to save your changes?</source>
     </message>
 </context>
 <context>
+    <name>startList_classes_condensed</name>
+    <message>
+        <location filename="plugins/Relays/qml/reports/startList_classes_condensed.qml" line="8"/>
+        <source>Start list by classes</source>
+        <translation type="unfinished">Стартовий протокол по групах</translation>
+    </message>
+</context>
+<context>
     <name>startList_classes_nstages</name>
     <message numerus="yes">
         <location filename="plugins/Runs/qml/reports/startList_classes_nstages.qml" line="14"/>
@@ -6374,6 +6426,14 @@ Do you want to save your changes?</source>
         <location filename="plugins/Runs/qml/reports/startList_clubs.qml" line="136"/>
         <source>R </source>
         <translation>R </translation>
+    </message>
+</context>
+<context>
+    <name>startList_clubs_condensed</name>
+    <message>
+        <location filename="plugins/Relays/qml/reports/startList_clubs_condensed.qml" line="8"/>
+        <source>Start list by clubs</source>
+        <translation type="unfinished">Стартовий протокол по клубах</translation>
     </message>
 </context>
 <context>

--- a/quickevent/app/quickevent/src/application.cpp
+++ b/quickevent/app/quickevent/src/application.cpp
@@ -71,7 +71,7 @@ Application *Application::instance(bool must_exist)
 int Application::dbVersion()
 {
 	// equals to minimal app version compatible with this DB
-	return 30200;
+	return 30401;
 }
 
 QString Application::versionString() const

--- a/quickevent/app/quickevent/src/appversion.h
+++ b/quickevent/app/quickevent/src/appversion.h
@@ -1,4 +1,4 @@
 #pragma once
 
-#define APP_VERSION "3.4.1"
+#define APP_VERSION "3.4.2"
 


### PR DESCRIPTION
Edit relay widget
 - Before attempting to delete, check if a runner has been selected.
 - When removing a runner from the relay, also remove him from the competitors table. Fix issue #697

Import event
 - When create new event from ORIS - import number of legs too

Classes 
 - Displays a warning when using an unsupported courses import type (inspired by #972)
 - Display number of relays per class in new column

Relays 
 - Show vacants in relay list (added column "Is Running")
 - Can add vacants (Menu->Relays->Add new vacants)
 - Can print startlist with/without vacants
 - Can print startlist with/without legs (runners)
 
![pbm_mo_staf_2025_03 E1_2025-06-24_23-55-47](https://github.com/user-attachments/assets/99abc974-9661-4335-8bb9-b28dd478f590)
