### PR TITLE
Searching relay runners by Bib, when using assign card to runner.

### DIFF
--- a/aqtinstall.log
+++ b/aqtinstall.log
@@ -1,0 +1,242 @@
+2026-08-12 23:49:04,433 - aqt.main - INFO - installer 25164 aqtinstall(aqt) v3.3.0 on Python 3.12.6 [CPython MSC v.1940 64 bit (AMD64)]
+2026-08-12 23:49:04,433 - aqt.helper - DEBUG - helper 25164 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/tools_mingw1310/Updates.xml.sha256
+2026-08-12 23:49:05,798 - aqt.helper - DEBUG - helper 25164 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/tools_mingw1310/Updates.xml.sha256
+2026-08-12 23:49:09,024 - aqt.helper - DEBUG - helper 23040 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/tools_mingw1310/qt.tools.win64_mingw1310/13.1.0-202407240918mingw1310.7z.sha256
+2026-08-12 23:49:09,703 - aqt.helper - INFO - helper 23040 Downloading qt.tools.win64_mingw1310...
+2026-08-12 23:49:09,704 - aqt.installer - DEBUG - installer 23040 Download URL: https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/tools_mingw1310/qt.tools.win64_mingw1310/13.1.0-202407240918mingw1310.7z
+2026-08-12 23:49:10,350 - aqt.helper - DEBUG - helper 23040 Asked to redirect(302) to: https://ftp.fau.de/qtproject/online/qtsdkrepository/windows_x86/desktop/tools_mingw1310/qt.tools.win64_mingw1310/13.1.0-202407240918mingw1310.7z
+2026-08-12 23:49:10,350 - aqt.helper - INFO - helper 23040 Redirected: ftp.fau.de
+2026-08-12 23:52:07,821 - aqt.installer - INFO - installer 23040 Finished installation of mingw1310.7z in 178.80199060
+2026-08-12 23:52:08,104 - aqt.main - INFO - installer 25164 Finished installation
+2026-08-12 23:52:08,104 - aqt.main - INFO - installer 25164 Time elapsed: 183.67112400 second
+2026-08-12 23:52:25,038 - aqt.main - INFO - installer 8740 aqtinstall(aqt) v3.3.0 on Python 3.12.6 [CPython MSC v.1940 64 bit (AMD64)]
+2026-08-12 23:52:25,039 - aqt.helper - DEBUG - helper 8740 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/tools_ninja/Updates.xml.sha256
+2026-08-12 23:52:26,474 - aqt.main - ERROR - installer 8740 The package 'tools_cmake' was not found while parsing XML of package information!
+==============================Suggested follow-up:==============================
+* Please use 'aqt list-tool windows desktop tools_ninja' to show tool variants available.
+2026-08-12 23:53:21,091 - aqt.helper - DEBUG - helper 23220 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/Updates.xml.sha256
+2026-08-12 23:53:36,385 - aqt.helper - DEBUG - helper 22548 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/Updates.xml.sha256
+2026-08-12 23:53:38,554 - aqt.helper - DEBUG - helper 22548 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/extensions/qtpdf/683/mingw/Updates.xml.sha256
+2026-08-12 23:53:40,372 - aqt.helper - DEBUG - helper 22548 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/extensions/qtwebengine/683/mingw/Updates.xml.sha256
+2026-08-12 23:53:41,067 - aqt.helper - DEBUG - helper 22548 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/extensions/qtwebengine/683/mingw/Updates.xml.sha256
+2026-08-12 23:53:41,820 - aqt.helper - DEBUG - helper 22548 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/extensions/qtwebengine/683/mingw/Updates.xml.sha256
+2026-08-12 23:53:42,476 - aqt.helper - DEBUG - helper 22548 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/extensions/qtwebengine/683/mingw/Updates.xml.sha256
+2026-08-12 23:53:43,096 - aqt.helper - DEBUG - helper 22548 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/extensions/qtwebengine/683/mingw/Updates.xml.sha256
+2026-08-12 23:53:49,135 - aqt.main - INFO - installer 8760 aqtinstall(aqt) v3.3.0 on Python 3.12.6 [CPython MSC v.1940 64 bit (AMD64)]
+2026-08-12 23:53:49,136 - aqt.helper - DEBUG - helper 8760 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/Updates.xml.sha256
+2026-08-12 23:53:50,555 - aqt.helper - DEBUG - helper 8760 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/extensions/qtwebengine/683/mingw/Updates.xml.sha256
+2026-08-12 23:53:51,203 - aqt.helper - DEBUG - helper 8760 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/extensions/qtwebengine/683/mingw/Updates.xml.sha256
+2026-08-12 23:53:52,049 - aqt.helper - DEBUG - helper 8760 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/extensions/qtwebengine/683/mingw/Updates.xml.sha256
+2026-08-12 23:53:52,759 - aqt.helper - DEBUG - helper 8760 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/extensions/qtwebengine/683/mingw/Updates.xml.sha256
+2026-08-12 23:53:53,472 - aqt.helper - DEBUG - helper 8760 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/extensions/qtwebengine/683/mingw/Updates.xml.sha256
+2026-08-12 23:53:54,151 - aqt.helper - DEBUG - helper 8760 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/extensions/qtpdf/683/mingw/Updates.xml.sha256
+2026-08-12 23:53:55,441 - aqt.archives - INFO - archives 8760 Found extension qtpdf
+2026-08-12 23:53:57,082 - aqt.helper - DEBUG - helper 22996 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308qtbase-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z.sha256
+2026-08-12 23:53:57,083 - aqt.helper - DEBUG - helper 18068 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.addons.qtconnectivity.win64_mingw/6.8.3-0-202503201308qtconnectivity-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z.sha256
+2026-08-12 23:53:57,094 - aqt.helper - DEBUG - helper 8412 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308qtsvg-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z.sha256
+2026-08-12 23:53:57,116 - aqt.helper - DEBUG - helper 23872 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308qtdeclarative-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z.sha256
+2026-08-12 23:53:58,257 - aqt.helper - INFO - helper 18068 Downloading qtconnectivity...
+2026-08-12 23:53:58,258 - aqt.installer - DEBUG - installer 18068 Download URL: https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.addons.qtconnectivity.win64_mingw/6.8.3-0-202503201308qtconnectivity-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z
+2026-08-12 23:53:58,301 - aqt.helper - INFO - helper 8412 Downloading qtsvg...
+2026-08-12 23:53:58,301 - aqt.installer - DEBUG - installer 8412 Download URL: https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308qtsvg-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z
+2026-08-12 23:53:58,330 - aqt.helper - INFO - helper 23872 Downloading qtdeclarative...
+2026-08-12 23:53:58,331 - aqt.installer - DEBUG - installer 23872 Download URL: https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308qtdeclarative-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z
+2026-08-12 23:53:58,369 - aqt.helper - INFO - helper 22996 Downloading qtbase...
+2026-08-12 23:53:58,370 - aqt.installer - DEBUG - installer 22996 Download URL: https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308qtbase-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z
+2026-08-12 23:53:59,261 - aqt.helper - DEBUG - helper 18068 Asked to redirect(302) to: https://ftp.fau.de/qtproject/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.addons.qtconnectivity.win64_mingw/6.8.3-0-202503201308qtconnectivity-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z
+2026-08-12 23:53:59,261 - aqt.helper - INFO - helper 18068 Redirected: ftp.fau.de
+2026-08-12 23:53:59,323 - aqt.helper - DEBUG - helper 8412 Asked to redirect(302) to: https://ftp.fau.de/qtproject/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308qtsvg-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z
+2026-08-12 23:53:59,323 - aqt.helper - INFO - helper 8412 Redirected: ftp.fau.de
+2026-08-12 23:53:59,367 - aqt.helper - DEBUG - helper 23872 Asked to redirect(302) to: https://ftp.fau.de/qtproject/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308qtdeclarative-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z
+2026-08-12 23:53:59,367 - aqt.helper - INFO - helper 23872 Redirected: ftp.fau.de
+2026-08-12 23:53:59,415 - aqt.helper - DEBUG - helper 22996 Asked to redirect(302) to: https://ftp.fau.de/qtproject/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308qtbase-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z
+2026-08-12 23:53:59,415 - aqt.helper - INFO - helper 22996 Redirected: ftp.fau.de
+2026-08-12 23:54:00,963 - aqt.installer - INFO - installer 8412 Finished installation of qtsvg-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z in 3.87409860
+2026-08-12 23:54:00,983 - aqt.helper - DEBUG - helper 8412 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308qttools-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z.sha256
+2026-08-12 23:54:01,780 - aqt.helper - INFO - helper 8412 Downloading qttools...
+2026-08-12 23:54:01,780 - aqt.installer - DEBUG - installer 8412 Download URL: https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308qttools-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z
+2026-08-12 23:54:01,990 - aqt.installer - INFO - installer 18068 Finished installation of qtconnectivity-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z in 4.91157300
+2026-08-12 23:54:02,023 - aqt.helper - DEBUG - helper 18068 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308qttranslations-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z.sha256
+2026-08-12 23:54:02,942 - aqt.helper - DEBUG - helper 8412 Asked to redirect(302) to: https://ftp.fau.de/qtproject/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308qttools-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z
+2026-08-12 23:54:02,943 - aqt.helper - INFO - helper 8412 Redirected: ftp.fau.de
+2026-08-12 23:54:03,533 - aqt.helper - INFO - helper 18068 Downloading qttranslations...
+2026-08-12 23:54:03,533 - aqt.installer - DEBUG - installer 18068 Download URL: https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308qttranslations-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z
+2026-08-12 23:54:04,587 - aqt.helper - DEBUG - helper 18068 Asked to redirect(302) to: https://ftp.fau.de/qtproject/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308qttranslations-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z
+2026-08-12 23:54:04,587 - aqt.helper - INFO - helper 18068 Redirected: ftp.fau.de
+2026-08-12 23:54:12,846 - aqt.installer - INFO - installer 18068 Finished installation of qttranslations-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z in 10.83110050
+2026-08-12 23:54:12,886 - aqt.helper - DEBUG - helper 18068 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308MinGW-w64-x86_64-13.1.0-release-posix-seh-msvcrt-rt_v11-rev1-runtime.7z.sha256
+2026-08-12 23:54:13,672 - aqt.helper - INFO - helper 18068 Downloading MinGW...
+2026-08-12 23:54:13,672 - aqt.installer - DEBUG - installer 18068 Download URL: https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308MinGW-w64-x86_64-13.1.0-release-posix-seh-msvcrt-rt_v11-rev1-runtime.7z
+2026-08-12 23:54:14,385 - aqt.helper - DEBUG - helper 18068 Asked to redirect(302) to: https://ftp.fau.de/qtproject/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308MinGW-w64-x86_64-13.1.0-release-posix-seh-msvcrt-rt_v11-rev1-runtime.7z
+2026-08-12 23:54:14,385 - aqt.helper - INFO - helper 18068 Redirected: ftp.fau.de
+2026-08-12 23:54:15,798 - aqt.installer - INFO - installer 18068 Finished installation of MinGW-w64-x86_64-13.1.0-release-posix-seh-msvcrt-rt_v11-rev1-runtime.7z in 2.91865480
+2026-08-12 23:54:15,829 - aqt.helper - DEBUG - helper 18068 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308d3dcompiler_47-x64.7z.sha256
+2026-08-12 23:54:16,569 - aqt.helper - INFO - helper 18068 Downloading d3dcompiler_47...
+2026-08-12 23:54:16,570 - aqt.installer - DEBUG - installer 18068 Download URL: https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308d3dcompiler_47-x64.7z
+2026-08-12 23:54:17,239 - aqt.helper - DEBUG - helper 18068 Asked to redirect(302) to: https://ftp.fau.de/qtproject/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308d3dcompiler_47-x64.7z
+2026-08-12 23:54:17,239 - aqt.helper - INFO - helper 18068 Redirected: ftp.fau.de
+2026-08-12 23:54:18,420 - aqt.installer - INFO - installer 18068 Finished installation of d3dcompiler_47-x64.7z in 2.59547590
+2026-08-12 23:54:19,652 - aqt.helper - DEBUG - helper 3836 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308opengl32sw-64-mesa_11_2_2-signed_sha256.7z.sha256
+2026-08-12 23:54:20,610 - aqt.helper - INFO - helper 3836 Downloading opengl32sw...
+2026-08-12 23:54:20,611 - aqt.installer - DEBUG - installer 3836 Download URL: https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308opengl32sw-64-mesa_11_2_2-signed_sha256.7z
+2026-08-12 23:54:21,289 - aqt.helper - DEBUG - helper 3836 Asked to redirect(302) to: https://ftp.fau.de/qtproject/online/qtsdkrepository/windows_x86/desktop/qt6_683/qt6_683/qt.qt6.683.win64_mingw/6.8.3-0-202503201308opengl32sw-64-mesa_11_2_2-signed_sha256.7z
+2026-08-12 23:54:21,289 - aqt.helper - INFO - helper 3836 Redirected: ftp.fau.de
+2026-08-12 23:54:32,467 - aqt.installer - INFO - installer 3836 Finished installation of opengl32sw-64-mesa_11_2_2-signed_sha256.7z in 12.81714100
+2026-08-12 23:54:53,586 - aqt.installer - INFO - installer 8412 Finished installation of qttools-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z in 52.60535260
+2026-08-12 23:56:30,977 - aqt.installer - INFO - installer 22996 Finished installation of qtbase-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z in 153.90056050
+2026-08-12 23:56:36,097 - aqt.installer - INFO - installer 23872 Finished installation of qtdeclarative-Windows-Windows_10_22H2-Mingw-Windows-Windows_10_22H2-X86_64.7z in 158.98331940
+2026-08-12 23:56:37,492 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\bin\qmake.exe
+2026-08-12 23:56:37,505 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6Bluetooth.pc
+2026-08-12 23:56:37,524 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6Concurrent.pc
+2026-08-12 23:56:37,547 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6Core.pc
+2026-08-12 23:56:37,568 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6DBus.pc
+2026-08-12 23:56:37,594 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6Designer.pc
+2026-08-12 23:56:37,615 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6Gui.pc
+2026-08-12 23:56:37,639 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6Help.pc
+2026-08-12 23:56:37,660 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6LabsAnimation.pc
+2026-08-12 23:56:37,683 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6LabsFolderListModel.pc
+2026-08-12 23:56:37,707 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6LabsPlatform.pc
+2026-08-12 23:56:37,731 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6LabsQmlModels.pc
+2026-08-12 23:56:37,760 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6LabsSettings.pc
+2026-08-12 23:56:37,859 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6LabsSharedImage.pc
+2026-08-12 23:56:37,900 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6LabsWavefrontMesh.pc
+2026-08-12 23:56:37,940 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6Linguist.pc
+2026-08-12 23:56:37,966 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6Multimedia.pc
+2026-08-12 23:56:37,994 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6MultimediaWidgets.pc
+2026-08-12 23:56:38,023 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6Network.pc
+2026-08-12 23:56:38,052 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6Nfc.pc
+2026-08-12 23:56:38,089 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6OpenGL.pc
+2026-08-12 23:56:38,119 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6OpenGLWidgets.pc
+2026-08-12 23:56:38,152 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6Platform.pc
+2026-08-12 23:56:38,184 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6PrintSupport.pc
+2026-08-12 23:56:38,211 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6Qml.pc
+2026-08-12 23:56:38,241 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QmlAssetDownloader.pc
+2026-08-12 23:56:38,279 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QmlCompiler.pc
+2026-08-12 23:56:38,311 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QmlCore.pc
+2026-08-12 23:56:38,335 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QmlIntegration.pc
+2026-08-12 23:56:38,359 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QmlLocalStorage.pc
+2026-08-12 23:56:38,388 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QmlMeta.pc
+2026-08-12 23:56:38,425 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QmlModels.pc
+2026-08-12 23:56:38,471 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QmlNetwork.pc
+2026-08-12 23:56:38,512 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QmlWorkerScript.pc
+2026-08-12 23:56:38,551 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QmlXmlListModel.pc
+2026-08-12 23:56:38,599 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6Quick.pc
+2026-08-12 23:56:38,640 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickControls2.pc
+2026-08-12 23:56:38,671 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickControls2Basic.pc
+2026-08-12 23:56:38,719 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickControls2BasicStyleImpl.pc
+2026-08-12 23:56:38,754 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickControls2FluentWinUI3StyleImpl.pc
+2026-08-12 23:56:38,814 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickControls2Fusion.pc
+2026-08-12 23:56:38,842 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickControls2FusionStyleImpl.pc
+2026-08-12 23:56:38,877 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickControls2Imagine.pc
+2026-08-12 23:56:38,916 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickControls2ImagineStyleImpl.pc
+2026-08-12 23:56:38,973 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickControls2Impl.pc
+2026-08-12 23:56:38,995 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickControls2Material.pc
+2026-08-12 23:56:39,023 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickControls2MaterialStyleImpl.pc
+2026-08-12 23:56:39,068 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickControls2Universal.pc
+2026-08-12 23:56:39,122 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickControls2UniversalStyleImpl.pc
+2026-08-12 23:56:39,164 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickControls2WindowsStyleImpl.pc
+2026-08-12 23:56:39,188 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickDialogs2.pc
+2026-08-12 23:56:39,212 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickDialogs2QuickImpl.pc
+2026-08-12 23:56:39,277 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickDialogs2Utils.pc
+2026-08-12 23:56:39,319 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickLayouts.pc
+2026-08-12 23:56:39,402 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickTemplates2.pc
+2026-08-12 23:56:39,452 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickTest.pc
+2026-08-12 23:56:39,494 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickVectorImage.pc
+2026-08-12 23:56:39,536 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6QuickWidgets.pc
+2026-08-12 23:56:39,575 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6SerialPort.pc
+2026-08-12 23:56:39,628 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6SpatialAudio.pc
+2026-08-12 23:56:39,691 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6Sql.pc
+2026-08-12 23:56:39,718 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6Svg.pc
+2026-08-12 23:56:39,784 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6SvgWidgets.pc
+2026-08-12 23:56:39,824 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6Test.pc
+2026-08-12 23:56:39,860 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6UiPlugin.pc
+2026-08-12 23:56:39,903 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6UiTools.pc
+2026-08-12 23:56:39,942 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6Widgets.pc
+2026-08-12 23:56:39,975 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\pkgconfig\Qt6Xml.pc
+2026-08-12 23:56:40,033 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6Bluetooth.prl
+2026-08-12 23:56:40,062 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6Concurrent.prl
+2026-08-12 23:56:40,101 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6Core.prl
+2026-08-12 23:56:40,144 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6DBus.prl
+2026-08-12 23:56:40,223 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6Designer.prl
+2026-08-12 23:56:40,270 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6DesignerComponents.prl
+2026-08-12 23:56:40,308 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6DeviceDiscoverySupport.prl
+2026-08-12 23:56:40,344 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6EntryPoint.prl
+2026-08-12 23:56:40,372 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6ExampleIcons.prl
+2026-08-12 23:56:40,408 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6ExamplesAssetDownloader.prl
+2026-08-12 23:56:40,451 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6FbSupport.prl
+2026-08-12 23:56:40,494 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6FFmpegMediaPluginImpl.prl
+2026-08-12 23:56:40,535 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6Gui.prl
+2026-08-12 23:56:40,623 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6Help.prl
+2026-08-12 23:56:40,662 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6LabsAnimation.prl
+2026-08-12 23:56:40,701 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6LabsFolderListModel.prl
+2026-08-12 23:56:40,767 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6LabsPlatform.prl
+2026-08-12 23:56:40,840 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6LabsQmlModels.prl
+2026-08-12 23:56:40,872 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6LabsSettings.prl
+2026-08-12 23:56:40,911 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6LabsSharedImage.prl
+2026-08-12 23:56:40,953 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6LabsWavefrontMesh.prl
+2026-08-12 23:56:40,987 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6Multimedia.prl
+2026-08-12 23:56:41,039 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6MultimediaQuick.prl
+2026-08-12 23:56:41,093 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6MultimediaTestLib.prl
+2026-08-12 23:56:41,155 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6MultimediaWidgets.prl
+2026-08-12 23:56:41,190 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6Network.prl
+2026-08-12 23:56:41,232 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6Nfc.prl
+2026-08-12 23:56:41,290 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6OpenGL.prl
+2026-08-12 23:56:41,318 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6OpenGLWidgets.prl
+2026-08-12 23:56:41,350 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6PacketProtocol.prl
+2026-08-12 23:56:41,389 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6PrintSupport.prl
+2026-08-12 23:56:41,417 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6Qml.prl
+2026-08-12 23:56:41,446 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QmlAssetDownloader.prl
+2026-08-12 23:56:41,482 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QmlCompiler.prl
+2026-08-12 23:56:41,514 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QmlCore.prl
+2026-08-12 23:56:41,574 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QmlDebug.prl
+2026-08-12 23:56:41,621 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QmlDom.prl
+2026-08-12 23:56:41,707 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QmlLocalStorage.prl
+2026-08-12 23:56:41,751 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QmlLS.prl
+2026-08-12 23:56:41,782 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QmlMeta.prl
+2026-08-12 23:56:41,806 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QmlModels.prl
+2026-08-12 23:56:41,834 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QmlNetwork.prl
+2026-08-12 23:56:41,859 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QmlToolingSettings.prl
+2026-08-12 23:56:41,890 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QmlTypeRegistrar.prl
+2026-08-12 23:56:41,927 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QmlWorkerScript.prl
+2026-08-12 23:56:41,976 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QmlXmlListModel.prl
+2026-08-12 23:56:42,007 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6Quick.prl
+2026-08-12 23:56:42,042 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6Quick3DSpatialAudio.prl
+2026-08-12 23:56:42,074 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickControls2.prl
+2026-08-12 23:56:42,103 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickControls2Basic.prl
+2026-08-12 23:56:42,150 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickControls2BasicStyleImpl.prl
+2026-08-12 23:56:42,186 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickControls2FluentWinUI3StyleImpl.prl
+2026-08-12 23:56:42,226 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickControls2Fusion.prl
+2026-08-12 23:56:42,284 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickControls2FusionStyleImpl.prl
+2026-08-12 23:56:42,334 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickControls2Imagine.prl
+2026-08-12 23:56:42,395 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickControls2ImagineStyleImpl.prl
+2026-08-12 23:56:42,441 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickControls2Impl.prl
+2026-08-12 23:56:42,492 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickControls2Material.prl
+2026-08-12 23:56:42,534 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickControls2MaterialStyleImpl.prl
+2026-08-12 23:56:42,578 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickControls2Universal.prl
+2026-08-12 23:56:42,634 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickControls2UniversalStyleImpl.prl
+2026-08-12 23:56:42,668 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickControls2WindowsStyleImpl.prl
+2026-08-12 23:56:42,707 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickControlsTestUtils.prl
+2026-08-12 23:56:42,744 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickDialogs2.prl
+2026-08-12 23:56:42,792 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickDialogs2QuickImpl.prl
+2026-08-12 23:56:42,841 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickDialogs2Utils.prl
+2026-08-12 23:56:42,869 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickEffects.prl
+2026-08-12 23:56:42,900 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickLayouts.prl
+2026-08-12 23:56:42,937 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickParticles.prl
+2026-08-12 23:56:42,975 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickShapes.prl
+2026-08-12 23:56:43,011 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickTemplates2.prl
+2026-08-12 23:56:43,072 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickTest.prl
+2026-08-12 23:56:43,121 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickTestUtils.prl
+2026-08-12 23:56:43,157 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickVectorImage.prl
+2026-08-12 23:56:43,200 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickVectorImageGenerator.prl
+2026-08-12 23:56:43,246 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6QuickWidgets.prl
+2026-08-12 23:56:43,291 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6SerialPort.prl
+2026-08-12 23:56:43,334 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6SpatialAudio.prl
+2026-08-12 23:56:43,358 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6Sql.prl
+2026-08-12 23:56:43,381 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6Svg.prl
+2026-08-12 23:56:43,409 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6SvgWidgets.prl
+2026-08-12 23:56:43,442 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6Test.prl
+2026-08-12 23:56:43,524 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6UiTools.prl
+2026-08-12 23:56:43,583 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6Widgets.prl
+2026-08-12 23:56:43,634 - aqt.updater - INFO - updater 8760 Patching C:\Users\Dell\Qt\6.8.3\mingw_64\lib\Qt6Xml.prl
+2026-08-12 23:56:43,702 - aqt.main - INFO - installer 8760 Finished installation
+2026-08-12 23:56:43,702 - aqt.main - INFO - installer 8760 Time elapsed: 174.56679130 second

--- a/quickevent/app/quickevent/plugins/CardReader/src/cardreaderwidget.cpp
+++ b/quickevent/app/quickevent/plugins/CardReader/src/cardreaderwidget.cpp
@@ -150,6 +150,17 @@ QVariant Model::data(const QModelIndex &index, int role) const
 		}
 	}
 	else if(role == Qt::DisplayRole) {
+		if(col == col_competirors_bib) {
+			bool is_relays = getPlugin<Event::EventPlugin>()->eventConfig().isRelays();
+			if(is_relays) {
+				int bib = tableRow(index.row()).value(QStringLiteral("competitors.startNumber")).toInt();
+				int leg = tableRow(index.row()).value(QStringLiteral("runs.leg")).toInt();
+				if(leg > 0) {
+					return QStringLiteral("%1/%2").arg(bib).arg(leg);
+				}
+				return bib > 0 ? QVariant(bib) : QVariant();
+			}
+		}
 		if(col == col_cards_checkTime
 		   || col == col_cards_startTime
 		   || col == col_cards_finishTime )
@@ -503,8 +514,8 @@ void CardReaderWidget::reload()
 	int current_stage = getPlugin<CardReaderPlugin>()->currentStageId();
 	qfs::QueryBuilder qb;
 	qb.select2("cards", "id, siId, runId, checkTime, startTime, finishTime, runIdAssignError")
-			.select2("runs", "id, startTimeMs, timeMs, finishTimeMs, misPunch, disqualified, badCheck, notStart, notFinish, disqualifiedByOrganizer, overTime, notCompeting, cardLent, cardReturned")
-			.select2("competitors", "registration, startNumber")
+			.select2("runs", "id, startTimeMs, timeMs, finishTimeMs, misPunch, disqualified, badCheck, notStart, notFinish, disqualifiedByOrganizer, overTime, notCompeting, cardLent, cardReturned, leg")
+			.select2("competitors", "registration")
 			.select2("classes", "name")
 			.select("COALESCE(lastName, '') || ' ' || COALESCE(firstName, '') AS competitorName")
 			.select("lentcards.siid IS NOT NULL AS cardLentTable")
@@ -516,10 +527,12 @@ void CardReaderWidget::reload()
 			.where("cards.stageId=" QF_IARG(current_stage))
 			.orderBy("cards.id DESC");
 	if(is_relays) {
+		qb.select("relays.number AS \"competitors.startNumber\"");
 		qb.join("runs.relayId", "relays.id");
 		qb.join("relays.classId", "classes.id");
 	}
 	else {
+		qb.select2("competitors", "startNumber");
 		qb.join("competitors.classId", "classes.id");
 	}
 	qfDebug() << qb.toString();

--- a/quickevent/app/quickevent/plugins/Runs/src/findrunneredit.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/findrunneredit.cpp
@@ -59,21 +59,29 @@ QVariant FindRunnersModel::data(const QModelIndex &index, int role) const
 		static int col_bib = fields.fieldIndex(QStringLiteral("competitors.startNumber"));
 		static int col_registration = fields.fieldIndex(QStringLiteral("registration"));
 		static auto col_siid = fields.fieldIndex(QStringLiteral("siid"));
+		static auto col_leg = fields.fieldIndex(QStringLiteral("runs.leg"));
 		static auto SI = QStringLiteral("SI:");
 		static auto BIB = QStringLiteral("Bib:");
+		QString bib_str = table_row.value(col_bib).toString();
+		if(col_leg >= 0) {
+			int leg = table_row.value(col_leg).toInt();
+			if(leg > 0) {
+				bib_str += QStringLiteral(" Leg:") + QString::number(leg);
+			}
+		}
 		if(role == Qt::DisplayRole) {
 			return table_row.value(col_class_name).toString() + ' '
 					+ table_row.value(col_name).toString() + ' '
 					+ table_row.value(col_registration).toString() + ' '
 					+ SI + table_row.value(col_siid).toString() + ' '
-					+ BIB + table_row.value(col_bib).toString();
+					+ BIB + bib_str;
 		}
 		if(role == Qt::EditRole) {
 			return table_row.value(col_class_name).toString() + ' '
 					+ table_row.value(col_searchkey).toString() + ' '
 					+ table_row.value(col_registration).toString() + ' '
 					+ SI + table_row.value(col_siid).toString() + ' '
-					+ BIB + table_row.value(col_bib).toString() + ' '
+					+ BIB + bib_str + ' '
 					+ table_row.value(col_name).toString();
 		}
 	}

--- a/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
@@ -79,16 +79,25 @@ RunsPlugin::~RunsPlugin() = default;
 const qf::core::utils::Table &RunsPlugin::runnersTable(int stage_id)
 {
 	if(m_runnersTableCacheStageId != stage_id) {
+		bool is_relays = getPlugin<EventPlugin>()->eventConfig().isRelays();
 		qfs::QueryBuilder qb;
-		qb.select2("competitors", "registration, startNumber")
+		qb.select2("competitors", "registration")
 				.select("COALESCE(lastName, '') || ' ' || COALESCE(firstName, '') AS competitorName")
-				.select2("runs", "id, siId, competitorId")
+				.select2("runs", "id, siId, competitorId, leg")
 				.select("runs.id AS runId")
 				.select2("classes", "name")
 				.from("competitors")
-				.join("competitors.classId", "classes.id")
 				.joinRestricted("competitors.id", "runs.competitorId", "runs.stageId=" QF_IARG(stage_id), "JOIN")
 				.orderBy("classes.name, lastName, firstName");
+		if(is_relays) {
+			qb.select("relays.number AS \"competitors.startNumber\"")
+					.join("runs.relayId", "relays.id")
+					.join("relays.classId", "classes.id");
+		}
+		else {
+			qb.select2("competitors", "startNumber")
+					.join("competitors.classId", "classes.id");
+		}
 		qf::gui::model::SqlTableModel m;
 		m.setQueryBuilder(qb, false);
 		m.reload();


### PR DESCRIPTION
When organizing a relay it is not possible to search runners by Bib, when using the "assign card to runner". All bibs default to 0.
<img width="559" height="365" alt="image" src="https://github.com/user-attachments/assets/6629d810-6adc-4e43-8199-c1b465f4001f" />

This commit fixes this problem.
<img width="562" height="254" alt="image" src="https://github.com/user-attachments/assets/8437c881-9bdb-4fe9-aac6-f5be85f193c5" />

