### PR TITLE
1110 Improve one-time Oris clubs import

### DIFF
--- a/quickevent/app/quickevent/plugins/Oris/src/orisimporter.cpp
+++ b/quickevent/app/quickevent/plugins/Oris/src/orisimporter.cpp
@@ -83,7 +83,7 @@ QNetworkAccessManager *OrisImporter::networkAccessManager()
 	return m_networkAccessManager;
 }
 
-void OrisImporter::getJsonAndProcess(const QUrl &url, QObject *context, std::function<void (const QJsonDocument &)> process_call_back)
+void OrisImporter::getJsonAndProcess(const QUrl &url, QObject *context, std::function<void (const QJsonDocument &)> process_call_back, std::function<void ()> finished_callback)
 {
 	auto *manager = networkAccessManager();
 	auto *reply = manager->get(QNetworkRequest(url));
@@ -91,7 +91,7 @@ void OrisImporter::getJsonAndProcess(const QUrl &url, QObject *context, std::fun
 		qf::gui::framework::MainWindow *fwk = qf::gui::framework::MainWindow::frameWork();
 		fwk->showProgress(QString("%1/%2 %3").arg(completed).arg(total).arg(reply->url().toString()), completed, total);
 	});
-	connect(reply, &QNetworkReply::finished, context, [reply, process_call_back]() {
+	connect(reply, &QNetworkReply::finished, context, [reply, process_call_back, finished_callback]() {
 		qfMessage() << "Get:" << reply->url().toString() << "OK:" << (reply->error() == QNetworkReply::NoError);
 		qf::gui::framework::MainWindow *fwk = qf::gui::framework::MainWindow::frameWork();
 		if(reply->error() == QNetworkReply::NoError) {
@@ -104,14 +104,17 @@ void OrisImporter::getJsonAndProcess(const QUrl &url, QObject *context, std::fun
 															   .arg(err.errorString())
 															   .arg(err.offset)
 															   .arg(data.mid(err.offset, 50).constData()));
-				return;
 			}
-			process_call_back(jsd);
+			else {
+				process_call_back(jsd);
+			}
 		}
 		else {
 			qf::gui::dialogs::MessageBox::showError(fwk, "http get error on: " + reply->url().toString() + ", " + reply->errorString());
 		}
 		reply->deleteLater();
+		if(finished_callback)
+			finished_callback();
 	});
 }
 
@@ -873,26 +876,35 @@ void OrisImporter::importClubs(std::function<void ()> success_callback)
 	});
 }
 
-void OrisImporter::getAndImportClub(const QString &club, const QString &key)
+void OrisImporter::getAndImportClub(const QString &club, const QString &key, std::function<void (bool)> finished_callback)
 {
-	QUrl url(QString("https://" + OrisImporter::orisDomainName() + "/API/?format=json&method=getClub&id=%1&eventkey=%2").arg(club).arg(key));
-	getJsonAndProcess(url, this, [club](const QJsonDocument &jsd) {
+	QUrl url(QString("https://" + OrisImporter::orisDomainName() + "/API/?format=json&method=getClub&abbr=%1&eventkey=%2").arg(club).arg(key));
+	auto imported = std::make_shared<bool>(false);
+	getJsonAndProcess(url, this, [club, imported](const QJsonDocument &jsd) {
 		saveJsonBackup(QString("Club_%1").arg(club), jsd);
 		QJsonObject data = jsd.object().value(QStringLiteral("Data")).toObject();
 		auto *fwk = qf::gui::framework::MainWindow::frameWork();
 		try {
 			qf::core::sql::Query q;
-			q.prepare("INSERT INTO clubs (name, abbr, importId) VALUES (:name, :abbr, :importId)", qf::core::Exception::Throw);
 			QString abbr = data.value(QStringLiteral("Abbr")).toString();
 			QString name = data.value(QStringLiteral("Name")).toString();
+			if(abbr.isEmpty()) {
+				qfWarning() << "Club" << club << "not found in ORIS";
+				return;
+			}
+			q.prepare("INSERT INTO clubs (name, abbr, importId) VALUES (:name, :abbr, :importId)", qf::core::Exception::Throw);
 			q.bindValue(":abbr", abbr);
 			q.bindValue(":name", name);
 			q.bindValue(":importId", data.value(QStringLiteral("ID")).toString().toInt());
 			q.exec(qf::core::Exception::Throw);
+			*imported = true;
 		}
 		catch (qf::core::Exception &e) {
 			qf::gui::dialogs::MessageBox::showException(fwk, e);
 		}
+	}, [imported, finished_callback]() {
+		if(finished_callback)
+			finished_callback(*imported);
 	});
 }
 
@@ -944,17 +956,26 @@ void OrisImporter::importMissingOneTimeClubs()
 			return;
 		}
 
-		int items_processed = 0;
 		int items_count = missing_clubs.size();
 		fwk->showProgress(tr("Importing one-time clubs"), 0, items_count);
 		qfLogScope("importClubs");
+		auto items_processed = std::make_shared<int>(0);
+		auto items_imported = std::make_shared<int>(0);
 		for (auto &abbr : missing_clubs) {
-			getAndImportClub(abbr, event_key);
-			items_processed++;
+			getAndImportClub(abbr, event_key, [fwk, items_count, items_processed, items_imported](bool imported) {
+				if(imported)
+					(*items_imported)++;
+				(*items_processed)++;
+				if(*items_processed < items_count)
+					return;
+				fwk->hideProgress();
+				qfInfo() << "Import of one-time clubs finished, imported:" << *items_imported << "of" << items_count;
+				qf::gui::dialogs::MessageBox::showInfo(fwk, tr("Import of one-time clubs finished.\n\nImported: %1 of %2 clubs.")
+															   .arg(*items_imported).arg(items_count));
+			});
 		}
 
-		fwk->hideProgress();
-		qfInfo() << "Import of"<< items_processed << "new one-time clubs started...";
+		qfInfo() << "Import of" << items_count << "new one-time clubs started...";
 	}
 	catch (qf::core::Exception &e) {
 		qf::gui::dialogs::MessageBox::showException(fwk, e);

--- a/quickevent/app/quickevent/plugins/Oris/src/orisimporter.h
+++ b/quickevent/app/quickevent/plugins/Oris/src/orisimporter.h
@@ -25,13 +25,13 @@ public:
 	void importMissingOneTimeClubs();
 
 	static void saveJsonBackup(const QString &fn, const QJsonDocument &jsd);
-	void getJsonAndProcess(const QUrl &url, QObject *context, std::function<void (const QJsonDocument &data)> process_call_back);
+	void getJsonAndProcess(const QUrl &url, QObject *context, std::function<void (const QJsonDocument &data)> process_call_back, std::function<void ()> finished_callback = nullptr);
 	void getTextAndProcess(const QUrl &url, QObject *context, std::function<void (const QByteArray &)> process_call_back);
 protected:
 	void syncEventEntries(int event_id, std::function<void()> success_callback);
 	void syncRelaysEntries(int event_id, std::function<void()> success_callback);
 
-	void getAndImportClub(const QString &club, const QString &key);
+	void getAndImportClub(const QString &club, const QString &key, std::function<void (bool imported)> finished_callback = nullptr);
 
 private:
 	QNetworkAccessManager *networkAccessManager();

--- a/quickevent/app/quickevent/src/appversion.h
+++ b/quickevent/app/quickevent/src/appversion.h
@@ -1,3 +1,3 @@
 #pragma once
 
-#define APP_VERSION "3.6.5"
+#define APP_VERSION "3.6.6"


### PR DESCRIPTION
Changes:
- switched to using `abbr` param in `getClub` request instead of `id` (implemented oris api upgrade) that causes problems when `id` value is higher than **99** (mainly for international events)
- added show info message box when successfully imported
- fix #1110