### PR TITLE
logwidget: Fix zoom_fitwidth icon

### DIFF
--- a/libqf/libqfgui/src/framework/logwidget.cpp
+++ b/libqf/libqfgui/src/framework/logwidget.cpp
@@ -107,7 +107,7 @@ LogWidget::LogWidget(QWidget *parent)
 	ui->setupUi(this);
 	ui->btClearLog->setIcon(qf::gui::Style::icon("clear"));
 	ui->btCopyToClipboard->setIcon(qf::gui::Style::icon("copy"));
-	ui->btResizeColumns->setIcon(qf::gui::Style::icon("zoom-fitwidth"));
+	ui->btResizeColumns->setIcon(qf::gui::Style::icon("zoom_fitwidth"));
 	ui->btTableMenu->setIcon(qf::gui::Style::icon("menu"));
 	//setPersistentSettingsId();
 	ui->btCopyToClipboard->setDefaultAction(ui->tableView->copySelectionToClipboardAction());

--- a/libqf/libqfgui/src/reports/widgets/reportviewwidget.cpp
+++ b/libqf/libqfgui/src/reports/widgets/reportviewwidget.cpp
@@ -601,7 +601,7 @@ qf::gui::framework::DialogWidget::ActionMap ReportViewWidget::createActions()
 	{
 		qf::gui::Action *a;
 		a = new qf::gui::Action(tr("Zoom to fit width"), this);
-		a->setIcon(qf::gui::Style::icon("zoom-fitwidth"));
+		a->setIcon(qf::gui::Style::icon("zoom_fitwidth"));
 		ret[QStringLiteral("view.zoomFitWidth")] = a;
 		connect(a, &QAction::triggered, this, &ReportViewWidget::view_zoomToFitWidth);
 	}


### PR DESCRIPTION
The correct name is with the underscore. The lucide iconset has the "dash version" of it, but the flat iconset does not, so instead of creating a new alias for the flat iconset, let's just fix the name.