### PR TITLE
Switch action build to Qt6.11.2

### DIFF
--- a/.github/actions/cmake/action.yml
+++ b/.github/actions/cmake/action.yml
@@ -35,8 +35,9 @@ runs:
         echo cmake_extra_args="'-DMINGW=ON' '-G MinGW Makefiles'" >> "$GITHUB_ENV"
       shell: bash
 
-    # Qt
+    # Qt for non-Windows using jurplel
     - name: Install Qt
+      if: runner.os != 'Windows'
       uses: jurplel/install-qt-action@v4
       with:
         cache: true
@@ -45,11 +46,17 @@ runs:
         install-deps: false
         modules: ${{ inputs.modules }}
     
-    #- name: Setup Ninja
-    #  uses: ashutoshvarma/setup-ninja@master
-    #  with:
-    #    # ninja version to download. Default: 1.10.0
-    #    version: 1.10.0
+    # Qt for Windows using jdpurcell with naqt enabled (aqtinstall still not support Qt6.11)
+    - name: Install Qt
+      if: runner.os == 'Windows'
+      uses: jdpurcell/install-qt-action@v5
+      with:
+        cache: true
+        version: ${{ inputs.qt_version }}
+        arch: ${{ inputs.qt_arch }}
+        install-deps: false
+        modules: ${{ inputs.modules }}
+        use-naqt: true
 
     - name: Get Git SHA
       run: echo "COMMIT_SHA=${GITHUB_SHA}" >> $GITHUB_ENV

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   ubuntu-qe3:
-    name: Qt 6.10 / Ubuntu 22.04
+    name: Qt 6.11 / Ubuntu 22.04
     runs-on: ubuntu-22.04
     steps:
       - name: Clone the repository
@@ -23,7 +23,7 @@ jobs:
       - name: Setup CMake
         uses: ./.github/actions/cmake
         with:
-          qt_version: 6.11.1
+          qt_version: 6.11.2
           use_qt6: ON
           modules: qtserialport qtmultimedia qtconnectivity
           additional_cmake_args: -DCMAKE_INSTALL_PREFIX='${{ github.workspace }}/install/usr'

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   windows:
-    name: Qt 6.10 / Windows
+    name: Qt 6.11 / Windows
     runs-on: windows-2025
     steps:
       - name: Clone the repository
@@ -62,7 +62,7 @@ jobs:
       - name: Setup CMake
         uses: ./.github/actions/cmake
         with:
-          qt_version: 6.10.3
+          qt_version: 6.11.2
           qt_arch: win64_mingw
           use_qt6: ON
           modules: qtserialport qtmultimedia qtconnectivity

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   macos:
-    name: Qt 6.10 / macOS 15
+    name: Qt 6.11 / macOS 15
     runs-on: macos-15
     steps:
       - name: Clone the repository
@@ -23,7 +23,7 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           cache: true
-          version: 6.11.1
+          version: 6.11.2
           install-deps: false
           modules: qtserialport qtmultimedia qtconnectivity
 


### PR DESCRIPTION
Action switched to Qt6.11.2 for Linux, Windows & Mac.

For Windows we use alternative library to get Qt6.11 
`aqtinstall` still not support Qt6.11, we now use `naqt` alternative