### PR TITLE
Fix QML report - start list classes in runs, set wider column for daytime.

### DIFF
--- a/quickevent/app/quickevent/plugins/Runs/qml/reports/startList_classes.qml
+++ b/quickevent/app/quickevent/plugins/Runs/qml/reports/startList_classes.qml
@@ -104,7 +104,7 @@ Report {
 							layout: Frame.LayoutHorizontal
 							function dataFn(field_name) {return function() {return rowData(field_name);}}
 							Cell {
-								width: 13
+								width: 15
 								halign: Frame.AlignRight
 								textFn: runnersDetail.dataFn("startTimeText");
 							}


### PR DESCRIPTION
When using daytime as the start time, there was not enough space for the entire string
<img width="359" height="291" alt="2026-09-08 16_53_07-Startovní listina po kategoriích" src="https://github.com/user-attachments/assets/34b4b6f7-fe10-468a-a658-de9d5cda7c00" />

Fixed
<img width="361" height="168" alt="2026-09-08 16_56_40-Startovní listina po kategoriích" src="https://github.com/user-attachments/assets/0d0f857f-2ec9-4afc-a68e-b04399a155ad" />
